### PR TITLE
Fix colonnes sheet, fiche avec images, drapeaux, lignes rose/bleu

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -18,30 +18,26 @@ function doPost(e) {
     var sheet = ss.getSheetByName(SHEET_NAME);
     if (!sheet) throw new Error('Feuille "' + SHEET_NAME + '" introuvable');
 
-    // Colonne E : "Collection — Référence" combiné
-    var collectionRef = [data.collection, data.reference]
-      .filter(function(v) { return v && v.trim(); })
-      .join(' — ');
-
-    // Ligne A → Q
+    // Ligne A → R (18 colonnes — collection et référence séparées)
     var row = [
       data.commande          || '',  // A  N° COMMANDE
       data.date              || '',  // B  DATE
       data.nom               || '',  // C  NOM
       data.telephone         || '',  // D  TÉLÉPHONE
-      collectionRef          || '',  // E  COLLECTION / RÉFÉRENCE
-      data.taille            || '',  // F  TAILLE
-      data.couleurTshirt     || '',  // G  COULEUR T-SHIRT
-      '',                            // H  T-SHIRT (manuel)
-      data.logoAvant         || '',  // I  LOGO AVANT
-      data.couleurLogoAvant  || '',  // J  COULEUR LOGO AVANT
-      data.logoArriere       || '',  // K  LOGO ARRIÈRE
-      data.couleurLogoArriere|| '',  // L  COULEUR LOGO ARRIÈRE
-      data.prixTshirt        || '',  // M  PRIX T-SHIRT
-      data.personnalisation  || '',  // N  PERSONNALISATION
-      data.total             || '',  // O  TOTAL
-      data.paye              || '',  // P  PAYÉ
-      ''                             // Q  FICHE (lien, défini via setFormula)
+      data.collection        || '',  // E  COLLECTION
+      data.reference         || '',  // F  RÉFÉRENCE
+      data.taille            || '',  // G  TAILLE
+      data.couleurTshirt     || '',  // H  COULEUR T-SHIRT
+      '',                            // I  T-SHIRT (manuel)
+      data.logoAvant         || '',  // J  LOGO AVANT
+      data.couleurLogoAvant  || '',  // K  COULEUR LOGO AVANT
+      data.logoArriere       || '',  // L  LOGO ARRIÈRE
+      data.couleurLogoArriere|| '',  // M  COULEUR LOGO ARRIÈRE
+      data.prixTshirt        || '',  // N  PRIX T-SHIRT
+      data.personnalisation  || '',  // O  PERSONNALISATION
+      data.total             || '',  // P  TOTAL
+      data.paye              || '',  // Q  PAYÉ
+      ''                             // R  FICHE (lien, défini via setFormula)
     ];
 
     // Force TÉLÉPHONE en texte — format AVANT pour conserve le + et le 0 initial
@@ -57,30 +53,39 @@ function doPost(e) {
     telCell.setNumberFormat('@');
     if (data.telephone) telCell.setValue(data.telephone);
 
-    // Colonne G (col 7) — fond = couleur du t-shirt
+    // Ligne entière — fond pastel rose (Femme) ou bleu (Homme)
+    var collectionLower = (data.collection || '').toLowerCase();
+    var rowRange = sheet.getRange(lastRow, 1, 1, row.length);
+    if (collectionLower.indexOf('femme') !== -1) {
+      rowRange.setBackground('#FFE8F0');  // Rose pastel
+    } else if (collectionLower.indexOf('homme') !== -1) {
+      rowRange.setBackground('#DCE8FF');  // Bleu pastel
+    }
+
+    // Colonne H (col 8) — fond = couleur réelle du t-shirt
     if (data.couleurTshirtHex) {
-      var tshirtCell = sheet.getRange(lastRow, 7);
+      var tshirtCell = sheet.getRange(lastRow, 8);
       tshirtCell.setBackground(data.couleurTshirtHex);
       tshirtCell.setFontColor(isColorDark_(data.couleurTshirtHex) ? '#FFFFFF' : '#1A1A1A');
       tshirtCell.setFontWeight('bold');
     }
 
-    // Colonne P (col 16) — couleur Apple selon statut paiement
-    var payCell   = sheet.getRange(lastRow, 16);
+    // Colonne Q (col 17) — couleur pastel Apple selon statut paiement
+    var payCell   = sheet.getRange(lastRow, 17);
     var payeUpper = (data.paye || '').toUpperCase();
     if (payeUpper === 'OUI') {
-      payCell.setBackground('#34C759');  // Apple green
-      payCell.setFontColor('#FFFFFF');
+      payCell.setBackground('#D9F5E4');  // Vert pastel Apple
+      payCell.setFontColor('#196030');
       payCell.setFontWeight('bold');
     } else {
-      payCell.setBackground('#FF3B30');  // Apple red
-      payCell.setFontColor('#FFFFFF');
+      payCell.setBackground('#FFE5E3');  // Rouge pastel Apple
+      payCell.setFontColor('#C01010');
       payCell.setFontWeight('bold');
     }
 
-    // Colonne Q (col 17) — lien vers la fiche atelier
+    // Colonne R (col 18) — lien vers la fiche atelier
     if (data.fiche) {
-      sheet.getRange(lastRow, 17).setFormula('=HYPERLINK("' + data.fiche + '","Voir fiche")');
+      sheet.getRange(lastRow, 18).setFormula('=HYPERLINK("' + data.fiche + '","Voir fiche")');
     }
 
     return jsonResponse_({ status: 'ok', row: lastRow });

--- a/index.html
+++ b/index.html
@@ -591,9 +591,9 @@
                 <span class="w-[70px] shrink-0 text-[13px] font-medium text-gray-400 uppercase tracking-wide">TEL</span>
                 <select id="countryCode"
                         class="shrink-0 bg-gray-100 rounded-lg text-[12px] font-semibold text-gray-600 border-0 outline-none focus:ring-0 cursor-pointer py-1 px-2 appearance-none">
-                    <option value="+590" selected>🇸🇽 +590</option>
-                    <option value="+33">🇫🇷 +33</option>
-                    <option value="+1">🇺🇸 +1</option>
+                    <option value="+590" selected>+590</option>
+                    <option value="+33">+33</option>
+                    <option value="+1">+1</option>
                 </select>
                 <input type="tel" id="clientPhone"
                        class="flex-1 bg-transparent appearance-none rounded-none outline-none border-0 text-[15px] font-semibold text-gray-900 tracking-tight py-1.5 placeholder:text-gray-300 placeholder:font-normal focus:ring-0"
@@ -1403,8 +1403,8 @@ function renderSvgToImg(svgStr, w, h) {
     });
 }
 
-async function captureMockup(shirtSvg, sideData, fabricHex) {
-    var W = 400, H = 480;
+async function captureMockup(shirtSvg, sideData, fabricHex, W, H, Q) {
+    W = W || 400; H = H || 480; Q = Q || 0.65;
     var c = document.createElement('canvas'); c.width = W; c.height = H;
     var cx = c.getContext('2d');
     cx.fillStyle = '#F5F5F7'; cx.fillRect(0, 0, W, H);
@@ -1436,7 +1436,7 @@ async function captureMockup(shirtSvg, sideData, fabricHex) {
         if (logoImg) cx.drawImage(logoImg, lx - lw / 2, ly - lh / 2, lw, lh);
     }
 
-    return c.toDataURL('image/jpeg', 0.65);
+    return c.toDataURL('image/jpeg', Q);
 }
 
 /* ══════════════════════════════════════
@@ -1481,7 +1481,11 @@ window.submit = async function() {
         paye              : payStatus === 'oui' ? 'OUI' : 'NON'
     };
 
-    /* ── Build fiche URL (sans images = URL légère ~2 Ko) ── */
+    /* ── Capture mockups réduits (220×264, JPEG 0.48) pour la fiche atelier ── */
+    var mockupFront = await captureMockup(svgF, logos.front, color.h, 220, 264, 0.48);
+    var mockupBack  = await captureMockup(svgB, logos.back,  color.h, 220, 264, 0.48);
+
+    /* ── Build fiche URL (~150 Ko avec images compressées) ── */
     const ATELIER_URL = 'https://ficheatelier.pages.dev';
     const ficheData = {
         commande          : payload.commande,
@@ -1498,7 +1502,9 @@ window.submit = async function() {
         couleurLogoArriere: payload.couleurLogoArriere,
         note              : payload.note,
         prix              : { tshirt: payload.prixTshirt, personnalisation: payload.personnalisation, total: payload.total },
-        paiement          : { statut: payload.paye }
+        paiement          : { statut: payload.paye },
+        mockupFront       : mockupFront,
+        mockupBack        : mockupBack
     };
     const ficheURL = ATELIER_URL + '#' + btoa(unescape(encodeURIComponent(JSON.stringify(ficheData))));
     payload.fiche = ficheURL;


### PR DESCRIPTION
APPS SCRIPT — google-apps-script.gs
- Séparation collection (E) + référence (F) : taille correct en G, couleur T-shirt en H → fini le décalage de colonnes
- Nouvelle numérotation : tshirtCell=8(H), payCell=17(Q), fiche=18(R)
- Ligne entière fond pastel : • Femme → Rose pastel #FFE8F0 • Homme → Bleu pastel #DCE8FF
- PAYÉ : couleurs pastel Apple (OUI #D9F5E4/#196030, NON #FFE5E3/#C01010) → fini les couleurs saturées plein blanc

FRONT-END — index.html
- Drapeaux retirés du select tel : 🇸🇽 +590 → +590, etc.
- captureMockup() accepte désormais W/H/Q optionnels
- Submit capture mockups réduits 220×264px JPEG 0.48 (≈50KB/image) et les inclut dans ficheData → la fiche atelier affiche les images avant/arrière
- ficheURL correctement généré avec les images compressées (~150KB total)

https://claude.ai/code/session_011Yx5Ex1JkBrKCbGYyrbfjR