### PR TITLE
Supprime le formatage automatique de couleur sur la colonne H

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -62,14 +62,6 @@ function doPost(e) {
       rowRange.setBackground('#DCE8FF');  // Bleu pastel
     }
 
-    // Colonne H (col 8) — fond = couleur réelle du t-shirt
-    if (data.couleurTshirtHex) {
-      var tshirtCell = sheet.getRange(lastRow, 8);
-      tshirtCell.setBackground(data.couleurTshirtHex);
-      tshirtCell.setFontColor(isColorDark_(data.couleurTshirtHex) ? '#FFFFFF' : '#1A1A1A');
-      tshirtCell.setFontWeight('bold');
-    }
-
     // Colonne Q (col 17) — couleur pastel Apple selon statut paiement
     var payCell   = sheet.getRange(lastRow, 17);
     var payeUpper = (data.paye || '').toUpperCase();


### PR DESCRIPTION
La colonne H recevait automatiquement un fond coloré (couleur du t-shirt), une couleur de texte contrastée et le gras. Ce comportement est retiré pour que la colonne H se comporte comme toutes les autres colonnes.

https://claude.ai/code/session_011Yx5Ex1JkBrKCbGYyrbfjR