### PR TITLE
Réf. rétablie, N° commande → 26-mmdd-nom, groupement par col A

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -41,14 +41,14 @@ function doPost(e) {
     ];
 
     // ── Insertion groupée : place la ligne après la dernière commande du même client ──
-    // La référence (ex: 26-17/02-Martin) est identique pour tous les t-shirts d'un même client.
+    // Le N° COMMANDE (ex: 26-0217-Martin) est identique pour tous les t-shirts du même client.
     var totalRows = sheet.getLastRow();
     var lastRow;
     var grouped = false;
-    if (data.reference && totalRows > 1) {
-      var refs = sheet.getRange(2, 6, totalRows - 1, 1).getValues();
-      for (var i = refs.length - 1; i >= 0; i--) {
-        if (refs[i][0] === data.reference) {
+    if (data.commande && totalRows > 1) {
+      var cmdVals = sheet.getRange(2, 1, totalRows - 1, 1).getValues();
+      for (var i = cmdVals.length - 1; i >= 0; i--) {
+        if (cmdVals[i][0] === data.commande) {
           var insertAt = i + 3;  // ligne i+2 dans le sheet → insérer avant i+3
           if (insertAt <= totalRows) {
             sheet.insertRowBefore(insertAt);

--- a/index.html
+++ b/index.html
@@ -1092,19 +1092,19 @@ window.go = function(n) {
 };
 
 /* ══════════════════════════════════════
-   SERIAL NUMBER (Annee–date–client)
+   SERIAL NUMBER (26-mmdd-client)
    ══════════════════════════════════════ */
 function updateSerial() {
     const d = new Date();
-    const year = d.getFullYear();
+    const yy   = String(d.getFullYear()).slice(-2);
     const mmdd = String(d.getMonth()+1).padStart(2,'0') + String(d.getDate()).padStart(2,'0');
     const raw  = (document.getElementById('clientName').value || '').trim();
     const name = raw.replace(/\s+/g, '-');
     const el = document.getElementById('orderNo');
     if (name) {
-        el.textContent = year + '\u2013' + mmdd + '\u2013' + name;
+        el.textContent = yy + '-' + mmdd + '-' + name;
     } else {
-        el.textContent = year + '\u2013' + mmdd + '\u2013...';
+        el.textContent = yy + '-' + mmdd + '-...';
     }
 }
 
@@ -1450,12 +1450,7 @@ window.submit = async function() {
 
     /* ── Build payload ── */
     const collVal = selects['selCollection'] ? selects['selCollection'].value : '';
-    /* Référence auto : 26-dd/mm-NomClient (ex: 26-17/02-Martin) */
-    const _rd = new Date();
-    const refVal = String(_rd.getFullYear()).slice(-2) + '-' +
-                   String(_rd.getDate()).padStart(2,'0') + '/' +
-                   String(_rd.getMonth()+1).padStart(2,'0') + '-' +
-                   (document.getElementById('clientName').value||'').trim().replace(/\s+/g,'-');
+    const refVal  = selects['selRef']        ? selects['selRef'].value        : '';
     const sizeVal = selects['selSize']       ? selects['selSize'].value       : '';
 
     const tel = (document.getElementById('countryCode').value || '') + ' ' +


### PR DESCRIPTION
RÉFÉRENCE (col F) : rétablie sur le sélecteur original (H-001, F-001...).

N° COMMANDE (col A) : nouveau format 26-mmdd-NomClient
(ex: 26-0217-Martin) — année 2 chiffres, tiret simple, mmdd, tiret, prénom.

GROUPEMENT : le script cherche désormais dans la colonne A (N° commande) pour regrouper les t-shirts d'un même client ; la commande étant identique pour tous les articles du même client le même jour.

https://claude.ai/code/session_011Yx5Ex1JkBrKCbGYyrbfjR