### PR TITLE
Stage côte à côte, logo arrière sélectionnable, resize Apple fluide

### DIFF
--- a/index.html
+++ b/index.html
@@ -1321,24 +1321,21 @@ function syncLogoUI() {
 function initLogoInteraction() {
     ['front', 'back'].forEach(s => {
         const zoneId = s === 'front' ? 'logoZoneFront' : 'logoZoneBack';
-        const viewId = s === 'front' ? 'svgViewFront' : 'svgViewBack';
         const zone   = document.getElementById(zoneId);
-        const stage  = document.getElementById(viewId);
-        if (!zone || !stage) return;
-
+        if (!zone) return;
         zone.addEventListener('pointerdown', e => onLogoDown(e, s));
-
-        // Désélection au clic en dehors de la zone logo
-        stage.addEventListener('pointerdown', e => {
-            if (!e.target.closest('#' + zoneId)) {
-                logoSelected = false;
-                zone.classList.remove('selected');
-            }
-        });
     });
 
     document.addEventListener('pointermove', onLogoMove);
     document.addEventListener('pointerup',   onLogoUp);
+
+    // Désélection globale : clic hors de tout logo-zone → tout désélectionner
+    document.addEventListener('pointerdown', e => {
+        if (!e.target.closest('.logo-zone')) {
+            logoSelected = false;
+            document.querySelectorAll('.logo-zone').forEach(z => z.classList.remove('selected'));
+        }
+    });
 
     // Sliders Y
     document.getElementById('sliderFrontY').addEventListener('input', e => {
@@ -1360,6 +1357,9 @@ function onLogoDown(e, activeSide) {
     /* Activer ce côté pour les sélecteurs */
     if (side !== activeSide) {
         side = activeSide;
+        // Désélectionner tous les logos (évite cadre bleu fantôme sur l'autre côté)
+        document.querySelectorAll('.logo-zone').forEach(z => z.classList.remove('selected'));
+        logoSelected = false;
         document.getElementById('logoSectionLabel').textContent =
             side === 'front' ? 'Design Logo Av' : 'Design Logo Ar';
         document.getElementById('colFront').classList.toggle('active', side === 'front');
@@ -1414,12 +1414,16 @@ function onLogoMove(e) {
     }
 
     if (dragState.type === 'resize') {
-        const distNow   = Math.hypot(e.clientX - dragState.centerX, e.clientY - dragState.centerY);
-        const distStart = Math.hypot(dragState.startX - dragState.centerX, dragState.startY - dragState.centerY);
-        if (distStart < 1) return;
-        const scale = distNow / distStart;
-        cur.w = Math.max(8,  Math.min(50, dragState.origW * scale));
-        cur.h = Math.max(6,  Math.min(40, dragState.origH * scale));
+        /* Apple-style : coin direct, linéaire, pas de ratio de distance */
+        const dx = e.clientX - dragState.startX;
+        const dy = e.clientY - dragState.startY;
+        const signX = dragState.corner.includes('e') ? 1 : -1;
+        const signY = dragState.corner.includes('s') ? 1 : -1;
+        const delta  = (signX * dx + signY * dy) * 0.5;
+        const pctChg = (delta / dragState.stageW) * 100 * 2.5;
+        const ratio  = dragState.origH / dragState.origW;
+        cur.w = Math.max(8,  Math.min(50, dragState.origW + pctChg));
+        cur.h = Math.max(6,  Math.min(40, cur.w * ratio));
         requestAnimationFrame(() => updateLogoPositionForSide(s));
     }
 }
@@ -1433,6 +1437,9 @@ function onLogoUp(e) {
    ══════════════════════════════════════ */
 window.flipSide = function(s) {
     side = s;
+    // Désélectionner tous les logos quand on switch de côté
+    logoSelected = false;
+    document.querySelectorAll('.logo-zone').forEach(z => z.classList.remove('selected'));
     document.getElementById('logoSectionLabel').textContent = s === 'front' ? 'Design Logo Av' : 'Design Logo Ar';
     document.getElementById('colFront').classList.toggle('active', s === 'front');
     document.getElementById('colBack').classList.toggle('active',  s === 'back');


### PR DESCRIPTION
- Affichage simultané Avant + Arrière dans le stage (2 colonnes)
- Clic sur un t-shirt → active ce côté → logo dropdown s'y applique
- Bordure bleue sur le côté actif (style iOS selection ring)
- Resize remplacé par algorithme linéaire direct (coin suit le doigt, sensibilité ×2.5, ratio d'aspect conservé) — fini le lag distance-based

https://claude.ai/code/session_011Yx5Ex1JkBrKCbGYyrbfjR