### PR TITLE
Fix: onclick manquant sur les colonnes pour activer le côté arrière

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,7 +671,7 @@
             <div class="shirts-grid" id="shirtsGrid">
 
                 <!-- ── Avant ── -->
-                <div class="shirt-col active" id="colFront">
+                <div class="shirt-col active" id="colFront" onclick="flipSide('front')">
                     <p class="shirt-side-label">Avant</p>
                     <div class="svg-view" id="svgViewFront">
                         <div class="svg-box" id="svgBoxFront"></div>
@@ -688,7 +688,7 @@
                 </div>
 
                 <!-- ── Arrière ── -->
-                <div class="shirt-col" id="colBack">
+                <div class="shirt-col" id="colBack" onclick="flipSide('back')">
                     <p class="shirt-side-label">Arrière</p>
                     <div class="svg-view" id="svgViewBack">
                         <div class="svg-box" id="svgBoxBack"></div>


### PR DESCRIPTION
Les divs colFront/colBack n'avaient aucun onclick → impossible de switcher le côté actif à "Arrière" sans avoir déjà un logo dessus. Ajout de onclick="flipSide('back')" sur colBack (et 'front' sur colFront).

https://claude.ai/code/session_011Yx5Ex1JkBrKCbGYyrbfjR