### PR TITLE
ID auto jjmmaa-hhmm-Nom-Prenom · suppression téléphone · Apple-style

### DIFF
--- a/ficheatelier-index.html
+++ b/ficheatelier-index.html
@@ -319,9 +319,8 @@
         <div class="fiche-header">
             <div class="flex justify-between items-start">
                 <div>
-                    <p class="text-[10px] text-zinc-500 font-black uppercase tracking-widest" id="fCommande"></p>
+                    <p class="text-[10px] text-zinc-400 font-black uppercase tracking-widest font-mono" id="fCommande"></p>
                     <h2 class="text-2xl font-bold mt-1" id="fNom"></h2>
-                    <p class="text-zinc-500 text-sm mt-1" id="fTel"></p>
                 </div>
                 <div class="text-right">
                     <span class="badge" id="fBadge"></span>
@@ -503,7 +502,6 @@ function renderFicheDetail(f) {
     /* Header */
     document.getElementById('fCommande').textContent = f.commande || '';
     document.getElementById('fNom').textContent = f.nom || '';
-    document.getElementById('fTel').textContent = f.telephone || '';
     document.getElementById('fDate').textContent = f.date || '';
 
     /* Badge paiement */
@@ -607,7 +605,7 @@ function buildWaMessage(f) {
     return 'Bonjour ' + nom + ' \uD83D\uDDA4\n\n' +
         'Votre commande OLDA est prête.\n' +
         lignes.join('\n') + '\n' +
-        'N\u00B0 ' + (f.commande || '') + '\n\n' +
+        'ID ' + (f.commande || '') + '\n\n' +
         'Vous pouvez venir la r\u00E9cup\u00E9rer quand vous le souhaitez. \uD83D\uDE0A\n\n' +
         '\u2014 OLDA Studio';
 }
@@ -697,9 +695,8 @@ window.ouvrirFiche = function(key) {
             '<div style="padding:28px 24px 20px;border-bottom:1px solid #2c2c2e;">' +
                 '<div class="flex justify-between items-start">' +
                     '<div>' +
-                        '<span class="text-[10px] text-zinc-500 font-black uppercase tracking-widest">' + (f.commande || '') + '</span>' +
+                        '<span class="text-[10px] text-zinc-500 font-black uppercase tracking-widest font-mono">' + (f.commande || '') + '</span>' +
                         '<h2 class="text-2xl font-bold mt-1 text-white">' + (f.nom || '') + '</h2>' +
-                        '<p class="text-zinc-500 text-sm mt-1">' + (f.telephone || '') + '</p>' +
                     '</div>' +
                     '<div class="text-right">' +
                         '<span class="badge ' + badgeClass + '">' + badgeText + '</span>' +

--- a/index.html
+++ b/index.html
@@ -607,46 +607,40 @@
     <div id="s1" class="step active mt-8">
         <div class="bg-white rounded-[32px] px-8 pt-9 pb-8" style="box-shadow:0 2px 16px rgba(0,0,0,0.04);">
 
-            <!-- N° de série (auto: Année–date–client) -->
-            <div class="flex items-baseline">
-                <span class="w-[70px] shrink-0 text-[13px] font-medium text-gray-400 uppercase tracking-wide">N&deg;</span>
-                <span class="text-[15px] font-semibold text-gray-900 tracking-tight" id="orderNo">&mdash;</span>
+            <!-- ID (auto: jjmmaa-hhmm-Nom-Prenom) -->
+            <div class="flex items-center gap-3 mb-1">
+                <span class="w-[60px] shrink-0 text-[10px] font-black text-gray-300 uppercase tracking-[0.18em]">ID</span>
+                <span class="text-[12px] font-mono font-semibold text-gray-400 tracking-tight select-all" id="orderNo">—</span>
             </div>
 
             <!-- Point median separator -->
-            <div class="py-1.5 pl-[70px]">
-                <span class="text-gray-300 text-[10px]">&bull;</span>
+            <div class="py-1.5 pl-[60px]">
+                <span class="text-gray-200 text-[10px]">&bull;</span>
             </div>
 
             <!-- DATE -->
             <div class="flex items-baseline">
-                <span class="w-[70px] shrink-0 text-[13px] font-medium text-gray-400 uppercase tracking-wide">DATE</span>
+                <span class="w-[60px] shrink-0 text-[10px] font-black text-gray-300 uppercase tracking-[0.18em]">DATE</span>
                 <span class="text-[15px] font-semibold text-gray-900" id="orderDate">15/02/2026</span>
             </div>
 
             <!-- Separator -->
             <div class="mt-6 mb-6 h-px bg-gray-100"></div>
 
-            <!-- CLIENT -->
-            <div class="flex items-center mb-6">
-                <span class="w-[70px] shrink-0 text-[13px] font-medium text-gray-400 uppercase tracking-wide">CLIENT</span>
-                <input type="text" id="clientName"
-                       class="flex-1 bg-transparent appearance-none rounded-none outline-none border-0 text-[15px] font-semibold text-gray-900 tracking-tight py-1.5 placeholder:text-gray-300 placeholder:font-normal focus:ring-0"
-                       placeholder="Nom du client">
+            <!-- NOM -->
+            <div class="flex items-center mb-5">
+                <span class="w-[60px] shrink-0 text-[10px] font-black text-gray-300 uppercase tracking-[0.18em]">NOM</span>
+                <input type="text" id="clientNom"
+                       class="flex-1 bg-transparent appearance-none rounded-none outline-none border-0 text-[17px] font-semibold text-gray-900 tracking-tight py-1 placeholder:text-gray-200 placeholder:font-normal focus:ring-0"
+                       placeholder="Dubois" autocomplete="family-name">
             </div>
 
-            <!-- TEL -->
-            <div class="flex items-center gap-2">
-                <span class="w-[70px] shrink-0 text-[13px] font-medium text-gray-400 uppercase tracking-wide">TEL</span>
-                <select id="countryCode"
-                        class="shrink-0 bg-gray-100 rounded-lg text-[12px] font-semibold text-gray-600 border-0 outline-none focus:ring-0 cursor-pointer py-1 px-2 appearance-none">
-                    <option value="+590" selected>+590</option>
-                    <option value="+33">+33</option>
-                    <option value="+1">+1</option>
-                </select>
-                <input type="tel" id="clientPhone"
-                       class="flex-1 bg-transparent appearance-none rounded-none outline-none border-0 text-[15px] font-semibold text-gray-900 tracking-tight py-1.5 placeholder:text-gray-300 placeholder:font-normal focus:ring-0"
-                       placeholder="06 00 00 00 00">
+            <!-- PRÉNOM -->
+            <div class="flex items-center">
+                <span class="w-[60px] shrink-0 text-[10px] font-black text-gray-300 uppercase tracking-[0.18em]">PRÉNOM</span>
+                <input type="text" id="clientPrenom"
+                       class="flex-1 bg-transparent appearance-none rounded-none outline-none border-0 text-[17px] font-semibold text-gray-900 tracking-tight py-1 placeholder:text-gray-200 placeholder:font-normal focus:ring-0"
+                       placeholder="Pierre" autocomplete="given-name">
             </div>
 
         </div>
@@ -1142,8 +1136,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     initLogoInteraction();
 
-    // Live serial number update when client name changes
-    document.getElementById('clientName').addEventListener('input', updateSerial);
+    // Live ID update quand le nom ou le prénom changent
+    document.getElementById('clientNom').addEventListener('input', updateSerial);
+    document.getElementById('clientPrenom').addEventListener('input', updateSerial);
+    updateSerial(); // génère l'ID dès l'ouverture
 
     // Close selects on outside click
     document.addEventListener('click', () => closeAllSelects());
@@ -1176,20 +1172,21 @@ window.go = function(n) {
 };
 
 /* ══════════════════════════════════════
-   SERIAL NUMBER (26-mmdd-client)
+   ID — jjmmaa-hhmm-Nom-Prenom
    ══════════════════════════════════════ */
+const _orderCreatedAt = new Date(); // heure figée à l'ouverture du formulaire
+
 function updateSerial() {
-    const d = new Date();
-    const yy   = String(d.getFullYear()).slice(-2);
-    const mmdd = String(d.getMonth()+1).padStart(2,'0') + String(d.getDate()).padStart(2,'0');
-    const raw  = (document.getElementById('clientName').value || '').trim();
-    const name = raw.replace(/\s+/g, '-');
-    const el = document.getElementById('orderNo');
-    if (name) {
-        el.textContent = yy + '-' + mmdd + '-' + name;
-    } else {
-        el.textContent = yy + '-' + mmdd + '-...';
-    }
+    const d  = _orderCreatedAt;
+    const dd = String(d.getDate()).padStart(2,'0');
+    const mm = String(d.getMonth()+1).padStart(2,'0');
+    const yy = String(d.getFullYear()).slice(-2);
+    const hh = String(d.getHours()).padStart(2,'0');
+    const mi = String(d.getMinutes()).padStart(2,'0');
+    const nom    = (document.getElementById('clientNom').value    || '').trim().replace(/\s+/g,'-');
+    const prenom = (document.getElementById('clientPrenom').value || '').trim().replace(/\s+/g,'-');
+    const namePart = nom && prenom ? `${nom}-${prenom}` : nom || prenom || '…';
+    document.getElementById('orderNo').textContent = `${dd}${mm}${yy}-${hh}${mi}-${namePart}`;
 }
 
 /* ══════════════════════════════════════
@@ -1562,16 +1559,13 @@ window.submit = async function() {
     const refVal  = selects['selRef']        ? selects['selRef'].value        : '';
     const sizeVal = selects['selSize']       ? selects['selSize'].value       : '';
 
-    const tel = (document.getElementById('countryCode').value || '') + ' ' +
-                (document.getElementById('clientPhone').value  || '');
-
     const logoColorName = (hex, arr) => (arr.find(c => c.h === hex) || { n: hex }).n;
 
     const payload = {
         commande          : document.getElementById('orderNo').textContent.trim(),
         date              : document.getElementById('orderDate').textContent.trim(),
-        nom               : document.getElementById('clientName').value.trim(),
-        telephone         : tel.trim(),
+        nom               : (document.getElementById('clientNom').value.trim() + ' ' +
+                             document.getElementById('clientPrenom').value.trim()).trim(),
         collection        : collVal || '',
         reference         : refVal  || '',
         taille            : sizeVal || '',
@@ -1600,7 +1594,6 @@ window.submit = async function() {
         commande          : payload.commande,
         date              : payload.date,
         nom               : payload.nom,
-        telephone         : payload.telephone,
         collection        : payload.collection,
         reference         : payload.reference,
         taille            : payload.taille,


### PR DESCRIPTION
- N° renommé en ID, format : jjmmaa-hhmm-Nom-Prenom (ex: 180226-1435-Dubois-Pierre)
- Horodatage figé à l'ouverture du formulaire (heure stable)
- Champ CLIENT séparé en deux : NOM + PRÉNOM pour alimenter l'ID
- Champ TEL entièrement supprimé (select +33/+590 et input)
- Labels ultra-épurés : 10px / font-black / tracking-[0.18em]
- Inputs : texte 17px, placeholders quasi invisibles (gray-200)
- Payload : telephone retiré, nom = Nom + Prénom concaténés
- ficheatelier : fTel masqué, ID affiché en mono, WhatsApp conservé

https://claude.ai/code/session_01WW26JsPfwnQPG1AfWkD4KE