### PR TITLE
Fix : bouton Changer applique le logo au bon côté (avant/arrière)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1812,7 +1812,7 @@ function updateSheetColorSection() {
 }
 
 window.openLogoSheet = function(s) {
-    if (s !== undefined) _sheetSide = s;
+    _sheetSide = (s !== undefined) ? s : side;
     document.getElementById('lsheetTitle').textContent = _sheetSide === 'front' ? 'Logo Avant' : 'Logo Arrière';
     buildSheetLogoGrid();
     updateSheetColorSection();


### PR DESCRIPTION
_sheetSide utilisait l'ancienne valeur quand openLogoSheet() était appelé sans argument (depuis la float bar). Maintenant il prend toujours le côté actif (variable side).

https://claude.ai/code/session_018PqtXd1GpzPX4REpRCo6Zn