### PR TITLE
Couleur T-shirt en menu déroulant + 12 couleurs logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -938,9 +938,8 @@
             </div>
 
 
-            <!-- Pastilles couleur Apple-style -->
-            <div class="color-dots-bar" id="colorDotsBar"></div>
-            <p class="text-center mt-1.5 text-[12px]" style="color:var(--text-2)" id="colorName">Blanc</p>
+            <!-- Couleur T-shirt — menu déroulant -->
+            <div class="aselect" id="colorSelect" style="margin-top:10px;"></div>
         </div>
 
         <!-- Collection -->
@@ -1171,8 +1170,10 @@ const COLORS = [
 ];
 
 const LOGO_COLORS = [
-    {n:'Noir',h:'#1A1A1A'},{n:'Blanc',h:'#FFFFFF'},{n:'Marine',h:'#00205B'},
-    {n:'Rouge',h:'#FF3B30'},{n:'Or',h:'#C5A44E'},{n:'Argent',h:'#A8A8A8'}
+    {n:'Noir',    h:'#1A1A1A'},{n:'Blanc',   h:'#FFFFFF'},{n:'Marine',  h:'#00205B'},
+    {n:'Rouge',   h:'#FF3B30'},{n:'Or',      h:'#C5A44E'},{n:'Argent',  h:'#A8A8A8'},
+    {n:'Royal',   h:'#003087'},{n:'Vert',    h:'#228B22'},{n:'Jaune',   h:'#FFD700'},
+    {n:'Rose',    h:'#FF69B4'},{n:'Orange',  h:'#FF6600'},{n:'Violet',  h:'#6B46C1'}
 ];
 
 const FABRIC_RE = /rgb\(100%,\s*100%,\s*100%\)/gi;
@@ -1325,22 +1326,27 @@ function colorDotHtml(hex, name) {
     return '<div style="display:flex;align-items:center;gap:10px;pointer-events:none;"><div style="width:22px;height:22px;border-radius:50%;background:' + hex + ';box-shadow:inset 0 0 0 0.5px rgba(0,0,0,0.12);flex-shrink:0;"></div><span>' + name + '</span></div>';
 }
 
-function initColorDots() {
-    const bar = document.getElementById('colorDotsBar');
-    if (!bar) return;
-    COLORS.forEach((c, i) => {
-        const dot = document.createElement('button');
-        dot.className = 'color-dot' + (i === 0 ? ' on' : '');
-        dot.style.background = c.h;
-        dot.setAttribute('aria-label', c.n);
-        dot.addEventListener('click', () => {
-            color = c;
-            renderSVG();
-            bar.querySelectorAll('.color-dot').forEach(d => d.classList.remove('on'));
-            dot.classList.add('on');
-        });
-        bar.appendChild(dot);
+function initColorSelect() {
+    const opts = COLORS.map(c => ({
+        v: c.h,
+        l: c.n,
+        html: '<div style="display:flex;align-items:center;gap:10px;pointer-events:none;"><div style="width:18px;height:18px;border-radius:50%;flex-shrink:0;background:' + c.h + ';box-shadow:inset 0 0 0 0.5px rgba(0,0,0,0.15);"></div><span>' + c.n + '</span></div>',
+        trigger: '<div style="display:flex;align-items:center;gap:8px;pointer-events:none;"><div style="width:16px;height:16px;border-radius:50%;flex-shrink:0;background:' + c.h + ';box-shadow:inset 0 0 0 0.5px rgba(0,0,0,0.15);"></div><span>' + c.n + '</span></div>'
+    }));
+    const sel = createRichSelect('colorSelect', opts, 'Couleur T-shirt', v => {
+        color = COLORS.find(c => c.h === v) || COLORS[0];
+        renderSVG();
     });
+    if (sel) {
+        sel.value = COLORS[0].h;
+        sel.label = COLORS[0].n;
+        sel._html = opts[0].trigger;
+        const trigger = document.querySelector('#colorSelect .aselect-trigger');
+        if (trigger) {
+            trigger.innerHTML = opts[0].trigger;
+            trigger.classList.remove('placeholder');
+        }
+    }
 }
 
 function createRichSelect(containerId, options, placeholder, onChange) {
@@ -1415,8 +1421,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.querySelector('#selSize .aselect-trigger').textContent = 'S';
     document.querySelector('#selSize .aselect-trigger').classList.remove('placeholder');
 
-    // Color dots (Apple-style pastilles)
-    initColorDots();
+    // Couleur T-shirt — menu déroulant
+    initColorSelect();
 
     // Logo interaction — géré directement depuis le t-shirt (bottom sheet)
 
@@ -1512,7 +1518,6 @@ function renderSide(s) {
 function renderSVG() {
     renderSide('front');
     renderSide('back');
-    document.getElementById('colorName').textContent = color.n;
 }
 
 function renderLogoForSide(s) {


### PR DESCRIPTION
- Remplace les pastilles couleur T-shirt par un menu déroulant Apple-style avec swatch coloré + nom pour chaque couleur
- Étend LOGO_COLORS de 6 à 12 couleurs : ajout Royal, Vert, Jaune, Rose, Orange, Violet

https://claude.ai/code/session_01GL4kxnMxKBrEVh5KBDD4HH