### PR TITLE
Paiement en lignes uniques + couleurs logo changeables

### DIFF
--- a/index.html
+++ b/index.html
@@ -983,32 +983,47 @@
          (M: Prix T-shirt, N: Personnalisation, O: Total, P: Paye, Q: Fiche)
          ════════════════════════════════════════ -->
     <div id="s3" class="step mt-6">
-        <div class="card p-6 space-y-5">
-            <div class="grid grid-cols-2 gap-4">
-                <div class="text-center">
-                    <p class="label mb-2">T-Shirt</p>
-                    <input type="number" id="price" class="input text-center font-bold text-lg" value="25" oninput="calcTotal()">
+        <div class="bg-white rounded-[32px] px-7 pt-7 pb-7" style="box-shadow:0 2px 16px rgba(0,0,0,0.04);">
+            <div class="divide-y divide-gray-100">
+
+                <!-- T-SHIRT -->
+                <div class="flex items-center py-3">
+                    <span class="w-28 shrink-0 text-[12px] font-black text-gray-300 uppercase tracking-[0.18em]">T-Shirt</span>
+                    <input type="number" id="price" value="25" oninput="calcTotal()"
+                           class="flex-1 bg-transparent text-[17px] font-semibold text-gray-900 tracking-tight outline-none border-0 focus:ring-0 text-right">
+                    <span class="ml-1 text-[17px] font-semibold text-gray-900">€</span>
                 </div>
-                <div class="text-center">
-                    <p class="label mb-2">Personnalisation</p>
-                    <input type="number" id="customPrice" class="input text-center font-bold text-lg" value="0" oninput="calcTotal()">
+
+                <!-- PERSO -->
+                <div class="flex items-center py-3">
+                    <span class="w-28 shrink-0 text-[12px] font-black text-gray-300 uppercase tracking-[0.18em]">Perso</span>
+                    <input type="number" id="customPrice" value="0" oninput="calcTotal()"
+                           class="flex-1 bg-transparent text-[17px] font-semibold text-gray-900 tracking-tight outline-none border-0 focus:ring-0 text-right">
+                    <span class="ml-1 text-[17px] font-semibold text-gray-900">€</span>
                 </div>
-            </div>
-            <div class="py-5 border-y text-center" style="border-color:var(--separator)">
-                <p class="text-[56px] font-black tracking-tighter leading-none" id="totalLabel">25 &euro;</p>
-            </div>
-            <div>
-                <p class="label mb-3 text-center">Statut du paiement</p>
-                <div class="space-y-2" id="payStatus">
-                    <button class="pay-opt on" data-p="non" onclick="setPay('non')"
-                        style="--pay-color:#FF3B30;--pay-bg:rgba(255,59,48,0.04);--pay-border:rgba(255,59,48,0.12);--pay-bg-on:rgba(255,59,48,0.08);--pay-border-on:rgba(255,59,48,0.35);">
-                        A regler
-                    </button>
-                    <button class="pay-opt" data-p="oui" onclick="setPay('oui')"
-                        style="--pay-color:#34C759;--pay-bg:rgba(52,199,89,0.04);--pay-border:rgba(52,199,89,0.12);--pay-bg-on:rgba(52,199,89,0.08);--pay-border-on:rgba(52,199,89,0.35);">
-                        Paye
-                    </button>
+
+                <!-- TOTAL -->
+                <div class="flex items-center py-3">
+                    <span class="w-28 shrink-0 text-[12px] font-black text-gray-300 uppercase tracking-[0.18em]">Total</span>
+                    <span class="flex-1 text-[17px] font-black text-gray-900 tracking-tight text-right" id="totalLabel">25</span>
+                    <span class="ml-1 text-[17px] font-black text-gray-900">€</span>
                 </div>
+
+                <!-- STATUT -->
+                <div class="flex items-center py-3 gap-3">
+                    <span class="w-28 shrink-0 text-[12px] font-black text-gray-300 uppercase tracking-[0.18em]">Statut</span>
+                    <div class="flex gap-2 flex-1" id="payStatus">
+                        <button class="pay-opt on" data-p="non" onclick="setPay('non')"
+                            style="flex:1;--pay-color:#FF3B30;--pay-bg:rgba(255,59,48,0.04);--pay-border:rgba(255,59,48,0.12);--pay-bg-on:rgba(255,59,48,0.08);--pay-border-on:rgba(255,59,48,0.35);">
+                            A régler
+                        </button>
+                        <button class="pay-opt" data-p="oui" onclick="setPay('oui')"
+                            style="flex:1;--pay-color:#34C759;--pay-bg:rgba(52,199,89,0.04);--pay-border:rgba(52,199,89,0.12);--pay-bg-on:rgba(52,199,89,0.08);--pay-border-on:rgba(52,199,89,0.35);">
+                            Payé
+                        </button>
+                    </div>
+                </div>
+
             </div>
         </div>
         <div class="flex gap-3">
@@ -1896,7 +1911,6 @@ function buildSheetLogoGrid() {
                 renderLogo();
                 updateSheetColorSection();
                 buildSheetLogoGrid();
-                closeLogoSheet();
             });
             g.appendChild(thumb);
         });
@@ -1953,7 +1967,7 @@ window.setPay = function(s) {
 
 window.calcTotal = function() {
     const t = (parseFloat(document.getElementById('price').value)||0) + (parseFloat(document.getElementById('customPrice').value)||0);
-    document.getElementById('totalLabel').innerHTML = t + ' &euro;';
+    document.getElementById('totalLabel').textContent = t;
 };
 
 /* ══════════════════════════════════════


### PR DESCRIPTION
- Step 3 : redesign en format ligne (même style que step 1) — T-shirt, Perso, Total et Statut chacun sur sa propre ligne horizontale ; boutons A régler / Payé côte à côte (flex) au lieu d'empilés
- calcTotal() : totalLabel affiche le chiffre seul (€ dans le HTML)
- Logo sheet : supprime le closeLogoSheet() automatique après sélection d'un logo → le sheet reste ouvert pour permettre de changer la couleur avant de fermer manuellement

https://claude.ai/code/session_01GL4kxnMxKBrEVh5KBDD4HH