### PR TITLE
Zoom luxe : remplace hover/long-press par bouton loupe discret

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,6 +887,20 @@
             text-align: center; margin-top: 14px;
             letter-spacing: 0.14em; text-transform: uppercase;
         }
+        /* Bouton loupe sur chaque shirt */
+        .shirt-zoom-btn {
+            position: absolute; bottom: 7px; right: 7px; z-index: 20;
+            width: 28px; height: 28px;
+            background: rgba(255,255,255,0.82);
+            backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+            border: none; border-radius: 50%;
+            display: flex; align-items: center; justify-content: center;
+            cursor: pointer;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.13);
+            transition: transform 0.14s, background 0.14s;
+            -webkit-tap-highlight-color: transparent;
+        }
+        .shirt-zoom-btn:active { transform: scale(0.88); background: white; }
     </style>
 </head>
 <body>
@@ -976,6 +990,9 @@
                     <p class="shirt-side-label">Avant</p>
                     <div class="svg-view" id="svgViewFront">
                         <div class="svg-box" id="svgBoxFront"></div>
+                        <button class="shirt-zoom-btn" onclick="showZoom('front')" title="Zoom">
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#1A1A1A" stroke-width="2.2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
+                        </button>
                         <div class="logo-tap-overlay logo-tap-front" id="logoTapFront">
                             <div class="logo-tap-pip">
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
@@ -994,6 +1011,9 @@
                     <p class="shirt-side-label">Arrière</p>
                     <div class="svg-view" id="svgViewBack">
                         <div class="svg-box" id="svgBoxBack"></div>
+                        <button class="shirt-zoom-btn" onclick="showZoom('back')" title="Zoom">
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#1A1A1A" stroke-width="2.2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
+                        </button>
                         <div class="logo-tap-overlay logo-tap-back" id="logoTapBack">
                             <div class="logo-tap-pip">
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
@@ -2210,61 +2230,27 @@ window.submit = async function() {
 };
 
 /* ══════════════════════════════════════
-   ZOOM LUXE — hover souris + long-press tactile
+   ZOOM LUXE — bouton loupe discret
    ══════════════════════════════════════ */
-(function() {
-    const overlay  = document.getElementById('shirtZoomOverlay');
-    const zoomCard = document.getElementById('shirtZoomCard');
-    const zoomLabel= document.getElementById('shirtZoomLabel');
-    const zoomView = document.getElementById('shirtZoomView');
-    let _zt = null, _moved = false;
-
-    function showZoom(side) {
-        const src = document.getElementById(side === 'front' ? 'svgViewFront' : 'svgViewBack');
-        if (!src) return;
-        const clone = src.cloneNode(true);
-        /* Retire les éléments interactifs du clone */
-        clone.querySelectorAll('.logo-tap-overlay, .logo-float-bar, .logo-frame').forEach(e => e.remove());
-        /* Cache les zones sans logo */
-        clone.querySelectorAll('.logo-zone.empty').forEach(e => { e.style.display = 'none'; });
-        clone.removeAttribute('id');
-        clone.style.cssText = 'position:relative;width:100%;aspect-ratio:5/6;overflow:hidden;';
-        zoomLabel.textContent = side === 'front' ? '— Avant —' : '— Arrière —';
-        zoomView.innerHTML = '';
-        zoomView.appendChild(clone);
-        overlay.classList.add('on');
-    }
-
-    function hideZoom() {
-        overlay.classList.remove('on');
-    }
-
-    /* Fermer en cliquant le backdrop */
-    overlay.addEventListener('click', hideZoom);
-    zoomCard.addEventListener('click', e => e.stopPropagation());
-
-    [['svgViewFront','front'], ['svgViewBack','back']].forEach(([id, side]) => {
-        const el = document.getElementById(id);
-        if (!el) return;
-
-        /* ── Souris (desktop) : hover 180ms ── */
-        el.addEventListener('mouseenter', () => {
-            _zt = setTimeout(() => showZoom(side), 180);
-        });
-        el.addEventListener('mouseleave', () => {
-            clearTimeout(_zt);
-            hideZoom();
-        });
-
-        /* ── Tactile (iPad / iPhone) : long-press 380ms ── */
-        el.addEventListener('touchstart', () => {
-            _moved = false;
-            _zt = setTimeout(() => { if (!_moved) showZoom(side); }, 380);
-        }, { passive: true });
-        el.addEventListener('touchmove',  () => { _moved = true; clearTimeout(_zt); }, { passive: true });
-        el.addEventListener('touchend',   () => { clearTimeout(_zt); }, { passive: true });
-    });
-})();
+window.showZoom = function(side) {
+    const src = document.getElementById(side === 'front' ? 'svgViewFront' : 'svgViewBack');
+    if (!src) return;
+    const clone = src.cloneNode(true);
+    clone.querySelectorAll('.logo-tap-overlay, .logo-float-bar, .logo-frame, .shirt-zoom-btn').forEach(e => e.remove());
+    clone.querySelectorAll('.logo-zone.empty').forEach(e => { e.style.display = 'none'; });
+    clone.removeAttribute('id');
+    clone.style.cssText = 'position:relative;width:100%;aspect-ratio:5/6;overflow:hidden;';
+    document.getElementById('shirtZoomLabel').textContent = side === 'front' ? '— Avant —' : '— Arrière —';
+    const v = document.getElementById('shirtZoomView');
+    v.innerHTML = '';
+    v.appendChild(clone);
+    document.getElementById('shirtZoomOverlay').classList.add('on');
+};
+window.hideZoom = function() {
+    document.getElementById('shirtZoomOverlay').classList.remove('on');
+};
+document.getElementById('shirtZoomOverlay').addEventListener('click', window.hideZoom);
+document.getElementById('shirtZoomCard').addEventListener('click', e => e.stopPropagation());
 
 })();
 </script>


### PR DESCRIPTION
Corrige le clignotement Mac (l'overlay couvrait le shirt déclenchant mouseleave en boucle) et le blocage du + sur iPhone (touchstart interceptait les taps avant le logo-sheet).

Solution : petit bouton loupe (28px, glass-morphism) en bas à droite de chaque shirt. Clic → overlay luxe. Clic en dehors → ferme. Aucun event hover ou touch sur le shirt → zéro conflit.

https://claude.ai/code/session_01GL4kxnMxKBrEVh5KBDD4HH