### PR TITLE
Zoom : scale sur svg-view entier pour garder logo en place

### DIFF
--- a/index.html
+++ b/index.html
@@ -822,12 +822,11 @@
         }
         .sf-btn-secondary:active { opacity: .6; }
         /* Zoom léger au survol — style Apple */
-        .svg-box svg, .svg-view .logo-zone {
+        .svg-view {
             transition: transform 0.38s cubic-bezier(0.4, 0, 0.2, 1);
             will-change: transform;
         }
-        .shirt-col:hover .svg-box svg,
-        .shirt-col:hover .svg-view .logo-zone {
+        .shirt-col:hover .svg-view {
             transform: scale(1.06);
         }
     </style>


### PR DESCRIPTION
SVG et logo-zone scalaient séparément depuis leurs centres respectifs → décalage. Désormais scale(1.06) sur .svg-view (parent commun) : shirt + logo bougent ensemble, positions relatives conservées.

https://claude.ai/code/session_01GL4kxnMxKBrEVh5KBDD4HH