### PR TITLE
pay-01 arrière : y 71 → 56 (−15%), taille alignée sur bea-16-ar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1230,7 +1230,7 @@ const LOGOS = {
         {id:'cor-3',n:'Crest',s:`<svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg"><ellipse cx="60" cy="58" rx="42" ry="45" stroke="#1A1A1A" stroke-width="2" fill="none"/><ellipse cx="60" cy="58" rx="35" ry="38" stroke="#1A1A1A" stroke-width="1" fill="none" opacity="0.3"/><text x="60" y="55" text-anchor="middle" font-family="Georgia,serif" font-size="22" font-weight="700" font-style="italic" fill="#1A1A1A">Cor</text><text x="60" y="72" text-anchor="middle" font-size="8" font-weight="600" fill="#1A1A1A" letter-spacing="5" font-family="sans-serif">PREMIERE</text><circle cx="60" cy="85" r="3" fill="#1A1A1A"/></svg>`}
     ],
     pay:[
-        {id:'pay-01',n:'Paysage 01',url:'pay01.svg',back:{x:47.9,y:71,w:63.84,h:42.56}}
+        {id:'pay-01',n:'Paysage 01',url:'pay01.svg',back:{x:47.9,y:56,w:67.2,h:44.8}}
     ]
 };
 


### PR DESCRIPTION
- y : 71 → 56 (montée de 15%)
- w : 63.84 → 67.2 / h : 42.56 → 44.8 (même taille que bea-16-ar)

https://claude.ai/code/session_018Zdvxpd4qGL77Kx6N8Y5Mk