### PR TITLE
Fix : logoMmInfo déplacé sous le t-shirt arrière uniquement

### DIFF
--- a/index.html
+++ b/index.html
@@ -950,8 +950,11 @@
                             <div class="logo-frame"></div>
                         </div>
                     </div>
+                    <!-- Largeur logo arrière en mm (H-001 uniquement) -->
+                    <div id="logoMmInfo" class="text-center mt-1 text-[11px] font-semibold" style="color:var(--accent);min-height:16px;letter-spacing:0.01em;" onclick="event.stopPropagation()"></div>
                 </div>
-            </div>
+
+            </div><!-- /shirts-grid -->
 
             <!-- Float bar logo (affiché quand un logo est placé sur le côté actif) -->
             <div class="logo-float-bar" id="logoFloatBar" style="display:none;">
@@ -959,10 +962,7 @@
                 <button class="fbar-btn fbar-remove" onclick="dropLogo()">Retirer</button>
             </div>
 
-            <!-- Largeurs logo en mm (mise à jour dynamique) -->
-            <div id="logoMmInfo" class="text-center mt-2 text-[12px] font-semibold" style="color:var(--accent);min-height:20px;letter-spacing:0.01em;"></div>
-
-        </div>
+        </div><!-- /stage -->
 
         <!-- Couleur T-shirt — menu déroulant -->
         <div class="card p-5 mt-3">


### PR DESCRIPTION
- div#logoMmInfo déplacé dans colBack (sous svgViewBack) → la largeur du logo arrière n'apparaît qu'en dessous du t-shirt arrière
- shirts-grid et float-bar restaurés à leur place correcte
- stopPropagation sur le div pour éviter le flipSide('back')

https://claude.ai/code/session_0146izWkYusXKykJD5YX71VG