### PR TITLE
fix: créer la fiche automatiquement via localStorage direct (sans ifr…

### DIFF
--- a/index.html
+++ b/index.html
@@ -2265,8 +2265,21 @@ window.submit = function() {
     /* ── Envoi Google Sheets (best-effort, non-bloquant) ── */
     fetch(API, { method: 'POST', mode: 'no-cors', body: JSON.stringify(payload) }).catch(() => {});
 
-    /* ── Sauvegarde silencieuse dans le localStorage de ficheatelier ── */
-    document.getElementById('ficheSaveFrame').src = ficheURL;
+    /* ── Sauvegarde directe dans localStorage (même domaine que ficheatelier) ── */
+    (function saveFicheLocale(f) {
+        try {
+            var STORAGE_KEY = 'olda_fiches';
+            var fiches = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+            var key = f.commande || ('cmd-' + Date.now());
+            if (fiches[key] && fiches[key].status) {
+                f.status = fiches[key].status;
+            } else {
+                f.status = 'en-attente';
+            }
+            fiches[key] = f;
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(fiches));
+        } catch(e) {}
+    })(Object.assign({}, ficheBase));
 
     /* ── Bouton fiche (lien prêt, ouverture manuelle uniquement) ── */
     const ficheLink = document.getElementById('sfFicheBtn');
@@ -2288,7 +2301,15 @@ window.submit = function() {
             ))));
             /* Met à jour le lien et re-sauvegarde avec mockups */
             document.getElementById('sfFicheBtn').href = ficheWithMockups;
-            document.getElementById('ficheSaveFrame').src = ficheWithMockups;
+            try {
+                var STORAGE_KEY = 'olda_fiches';
+                var fiches = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+                var key = ficheBase.commande || ('cmd-' + Date.now());
+                var ficheWithMockupsData = Object.assign({}, ficheBase, { mockupFront: mF, mockupBack: mB });
+                if (fiches[key]) ficheWithMockupsData.status = fiches[key].status;
+                fiches[key] = ficheWithMockupsData;
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(fiches));
+            } catch(e) {}
         } catch(e) { /* silencieux — la fiche sans mockup reste disponible via le bouton */ }
     })();
 
@@ -2307,6 +2328,5 @@ window.submit = function() {
 })();
 </script>
 
-<iframe id="ficheSaveFrame" style="display:none;width:0;height:0;border:none;" sandbox="allow-scripts allow-same-origin"></iframe>
 </body>
 </html>


### PR DESCRIPTION
…ame)

Remplace l'iframe par une écriture directe dans localStorage (clé olda_fiches), identique à la logique de saveFiche() dans ficheatelier-index.html. Les deux fichiers étant sur le même domaine, le localStorage est partagé. La fiche est créée à la soumission, puis mise à jour avec les mockups.

https://claude.ai/code/session_012TSm9PQffyszKJwJpj8CVq