### PR TITLE
Auto-save fiche récapitulative to localStorage on order submit

### DIFF
--- a/index.html
+++ b/index.html
@@ -2363,9 +2363,22 @@ window.submit = async function() {
     /* ── Création automatique de la fiche sur le Dashboard OLDA ── */
     sendOrderToDashboard(payload, ficheComplete).catch(e => console.error('[OLDA Dashboard] Erreur inattendue:', e));
 
-    /* ── Bouton fiche → Dashboard ── */
+    /* ── Sauvegarde locale de la fiche récapitulative (ficheatelier-index.html) ── */
+    try {
+        var ficheKey = ficheComplete.commande || ('cmd-' + Date.now());
+        var allFiches = JSON.parse(localStorage.getItem('olda_fiches') || '{}');
+        if (!ficheComplete.status) ficheComplete.status = 'en-attente';
+        allFiches[ficheKey] = ficheComplete;
+        localStorage.setItem('olda_fiches', JSON.stringify(allFiches));
+        console.info('[OLDA Fiche] Fiche récapitulative sauvegardée:', ficheKey);
+    } catch(ficheErr) {
+        console.warn('[OLDA Fiche] Erreur sauvegarde locale:', ficheErr.message);
+    }
+
+    /* ── Bouton fiche → Fiche récapitulative atelier ── */
     const ficheLink = document.getElementById('sfFicheBtn');
-    ficheLink.href = DASHBOARD_URL;
+    ficheLink.href = 'ficheatelier-index.html';
+    ficheLink.textContent = 'Voir la fiche récapitulative ›';
 
     /* ── Success overlay ── */
     const overlay = document.getElementById('successOverlay');


### PR DESCRIPTION
When an order is submitted, the fiche complète (with mockups, details, workflow status) is now saved to localStorage under 'olda_fiches' so ficheatelier-index.html can display it immediately. The success button now links to the fiche atelier dashboard instead of the Railway backend.

https://claude.ai/code/session_012cbUBxjMWbeLKSwpKkVojD