### PR TITLE
perf: add nixpacks.toml to speed up Railway builds

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,5 @@
+[phases.install]
+cmds = ["npm ci --omit=dev"]
+
+[start]
+cmd = "node server.js"


### PR DESCRIPTION
Utilise npm ci --omit=dev au lieu de npm install :
- npm ci est plus rapide grâce au package-lock.json
- --omit=dev exclut les dépendances de développement inutiles

https://claude.ai/code/session_01K7qsKewAr5uprfnx5n8F2q