### PR TITLE
fix: root URL ouvre le dashboard via variable SITE_MODE

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,9 +14,15 @@ app.use(express.static(path.join(__dirname), {
     }
 }));
 
-/* Route par défaut → index.html */
+/* Route par défaut :
+   - SITE_MODE=dashboard  → ficheatelier-index.html  (déploiement atelier interne)
+   - sinon                → index.html               (site client public)          */
+const ROOT_FILE = process.env.SITE_MODE === 'dashboard'
+    ? 'ficheatelier-index.html'
+    : 'index.html';
+
 app.get('/', (req, res) => {
-    res.sendFile(path.join(__dirname, 'index.html'));
+    res.sendFile(path.join(__dirname, ROOT_FILE));
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
SITE_MODE=dashboard → ficheatelier-index.html à la racine sinon → index.html (site client)

https://claude.ai/code/session_01K7qsKewAr5uprfnx5n8F2q