### PR TITLE
feat: synchronisation temps réel des commandes via Socket.io

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -215,57 +215,83 @@
 
 </div>
 
+<script src="/socket.io/socket.io.js"></script>
 <script>
-    // Correspondance statut → id HTML
     const STATS_IDS = [
-        'en_attente',
-        'a_preparer',
-        'maquette_a_faire',
-        'prt_a_faire',
-        'validation',
-        'impression',
-        'pressage',
-        'client_a_contacter',
-        'client_prevenu',
-        'archives'
+        'en_attente', 'a_preparer', 'maquette_a_faire', 'prt_a_faire',
+        'validation', 'impression', 'pressage', 'client_a_contacter',
+        'client_prevenu', 'archives'
     ];
 
-    async function chargerStats() {
-        try {
-            const resp = await fetch('/api/stats');
-            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-            const data = await resp.json();
-
-            // Mettre à jour chaque compteur
-            STATS_IDS.forEach(statut => {
-                const el = document.getElementById('stat-' + statut);
-                if (el) {
-                    el.textContent = data.stats[statut] ?? 0;
-                    el.classList.remove('chargement');
-                }
-            });
-
-            // Mettre à jour le badge total
-            const badge = document.getElementById('badge-total');
-            badge.textContent = data.total + ' commande' + (data.total !== 1 ? 's' : '');
-
-            // Indicateur de sync
-            const sync = document.getElementById('sync-status');
-            const heure = new Date().toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-            sync.textContent = 'Mis à jour à ' + heure;
-            sync.classList.remove('erreur');
-
-        } catch (err) {
-            const sync = document.getElementById('sync-status');
-            sync.textContent = 'Erreur de connexion — nouvelle tentative dans 30 s';
-            sync.classList.add('erreur');
-        }
+    function appliquerStats(data) {
+        STATS_IDS.forEach(statut => {
+            const el = document.getElementById('stat-' + statut);
+            if (el) {
+                el.textContent = data.stats[statut] ?? 0;
+                el.classList.remove('chargement');
+            }
+        });
+        const badge = document.getElementById('badge-total');
+        badge.textContent = data.total + ' commande' + (data.total !== 1 ? 's' : '');
     }
 
-    // Chargement immédiat puis toutes les 30 secondes
-    chargerStats();
-    setInterval(chargerStats, 30000);
+    function afficherSync(texte, erreur) {
+        const sync = document.getElementById('sync-status');
+        sync.textContent = texte;
+        erreur ? sync.classList.add('erreur') : sync.classList.remove('erreur');
+    }
+
+    function heureNow() {
+        return new Date().toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    }
+
+    /* ── Connexion Socket.io ── */
+    const socket = io({ transports: ['websocket', 'polling'] });
+
+    socket.on('connect', () => {
+        afficherSync('Connecté — en attente de commandes…', false);
+    });
+
+    socket.on('disconnect', () => {
+        afficherSync('Connexion perdue — reconnexion…', true);
+    });
+
+    /* Mise à jour instantanée des compteurs à chaque commande reçue */
+    socket.on('stats-update', (data) => {
+        appliquerStats(data);
+        afficherSync('Mis à jour à ' + heureNow(), false);
+    });
+
+    /* Notification visuelle à chaque nouvelle commande */
+    socket.on('new-order', (order) => {
+        const notif = document.createElement('div');
+        notif.style.cssText = [
+            'position:fixed', 'bottom:24px', 'left:50%', 'transform:translateX(-50%)',
+            'background:#1c1c1e', 'color:#fff', 'padding:14px 22px',
+            'border-radius:14px', 'font-size:14px', 'font-weight:600',
+            'box-shadow:0 4px 20px rgba(0,0,0,0.3)', 'z-index:9999',
+            'animation:fadeIn .25s ease'
+        ].join(';');
+        notif.textContent = '🆕 Nouvelle commande — ' + order.nom + ' (' + order.commande + ')';
+        document.body.appendChild(notif);
+        setTimeout(() => notif.remove(), 4500);
+    });
+
+    /* ── Fallback HTTP : chargement initial si socket lent ── */
+    async function chargerStatsFallback() {
+        try {
+            const resp = await fetch('/api/stats');
+            if (!resp.ok) return;
+            const data = await resp.json();
+            appliquerStats(data);
+            afficherSync('Chargé à ' + heureNow(), false);
+        } catch (_) { /* socket prend le relais */ }
+    }
+    chargerStatsFallback();
 </script>
+<style>
+    @keyframes fadeIn { from { opacity:0; transform:translateX(-50%) translateY(8px); } to { opacity:1; transform:translateX(-50%) translateY(0); } }
+</style>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1211,7 +1211,7 @@
 const API = "https://script.google.com/macros/s/AKfycbyzeU0tD22L8wZ94PW0f4s1a2LH7fNPhK74RtjcIXs0pWAP59anDV8EYtYlP8WX5iCk/exec";
 
 /* ── Dashboard OLDA — même domaine que le formulaire ── */
-const DASHBOARD_URL   = window.location.origin;
+const DASHBOARD_URL   = 'https://dashboardolda-production.up.railway.app';
 const DASHBOARD_TOKEN = "d1e9c4cd170eb57f8ce6254b5aa70b7f708e465d48daefc7f3b0b7e16bd9f4dc";
 
 const COLORS = [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "socket.io": "^4.7.5"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/server.js
+++ b/server.js
@@ -1,30 +1,136 @@
 const express = require('express');
 const path    = require('path');
+const http    = require('http');
+const { Server } = require('socket.io');
 
-const app  = express();
-const PORT = process.env.PORT || 3000;
+const app    = express();
+const server = http.createServer(app);
+const PORT   = process.env.PORT || 3000;
 
-/* Servir tous les fichiers statiques du répertoire courant */
+const IS_DASHBOARD    = process.env.SITE_MODE === 'dashboard';
+const DASHBOARD_TOKEN = process.env.DASHBOARD_TOKEN || 'd1e9c4cd170eb57f8ce6254b5aa70b7f708e465d48daefc7f3b0b7e16bd9f4dc';
+const CLIENT_ORIGIN   = process.env.CLIENT_ORIGIN  || 'https://oldastudio.up.railway.app';
+
+/* ── Stockage mémoire des commandes (dashboard uniquement) ── */
+const orders = new Map();
+
+const STATUS_KEYS = [
+    'en_attente', 'a_preparer', 'maquette_a_faire', 'prt_a_faire',
+    'validation', 'impression', 'pressage', 'client_a_contacter',
+    'client_prevenu', 'archives'
+];
+
+function computeStats() {
+    const stats = {};
+    STATUS_KEYS.forEach(k => { stats[k] = 0; });
+    for (const order of orders.values()) {
+        const s = order.statut || 'en_attente';
+        if (Object.prototype.hasOwnProperty.call(stats, s)) stats[s]++;
+        else stats['en_attente']++;
+    }
+    return { stats, total: orders.size };
+}
+
+/* ── Socket.io (dashboard uniquement) ── */
+let io = null;
+if (IS_DASHBOARD) {
+    io = new Server(server, {
+        cors: {
+            origin: [CLIENT_ORIGIN, 'http://localhost:3000'],
+            methods: ['GET', 'POST']
+        }
+    });
+
+    io.on('connection', (socket) => {
+        console.log('[Socket.io] Client connecté :', socket.id);
+        /* Envoyer les stats actuelles au nouveau client */
+        socket.emit('stats-update', computeStats());
+        socket.on('disconnect', () => {
+            console.log('[Socket.io] Client déconnecté :', socket.id);
+        });
+    });
+}
+
+/* ── CORS pour les requêtes cross-origin du site client ── */
+app.use((req, res, next) => {
+    res.setHeader('Access-Control-Allow-Origin',  CLIENT_ORIGIN);
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    if (req.method === 'OPTIONS') return res.sendStatus(204);
+    next();
+});
+
+app.use(express.json({ limit: '15mb' }));
+
+/* ── Fichiers statiques ── */
 app.use(express.static(path.join(__dirname), {
     setHeaders(res, filePath) {
-        /* Pas de cache pour les fichiers HTML — toujours la dernière version */
         if (filePath.endsWith('.html')) {
             res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
         }
     }
 }));
 
-/* Route par défaut :
-   - SITE_MODE=dashboard  → ficheatelier-index.html  (déploiement atelier interne)
-   - sinon                → index.html               (site client public)          */
-const ROOT_FILE = process.env.SITE_MODE === 'dashboard'
-    ? 'ficheatelier-index.html'
-    : 'index.html';
+/* ── API Commandes (dashboard uniquement) ── */
+if (IS_DASHBOARD) {
+
+    /* POST /api/orders — reçoit une commande du site client */
+    app.post('/api/orders', (req, res) => {
+        const auth = req.headers['authorization'] || '';
+        if (auth !== 'Bearer ' + DASHBOARD_TOKEN) {
+            return res.status(401).json({ error: 'Non autorisé' });
+        }
+
+        const order = req.body;
+        if (!order || !order.commande) {
+            return res.status(400).json({ error: 'Données manquantes (champ commande requis)' });
+        }
+
+        /* Initialisation */
+        if (!order.statut) order.statut = 'en_attente';
+        order._reçuLe = new Date().toISOString();
+
+        orders.set(order.commande, order);
+
+        console.log('[Dashboard] Nouvelle commande :', order.commande, '—', order.nom);
+
+        /* Diffusion temps réel à tous les clients dashboard connectés */
+        if (io) {
+            io.emit('new-order', {
+                commande  : order.commande,
+                nom       : order.nom,
+                statut    : order.statut,
+                timestamp : order._reçuLe
+            });
+            io.emit('stats-update', computeStats());
+        }
+
+        res.status(201).json({ ok: true, commande: order.commande });
+    });
+
+    /* GET /api/stats — statistiques par statut */
+    app.get('/api/stats', (req, res) => {
+        res.json(computeStats());
+    });
+
+    /* GET /api/orders — liste complète (protégée) */
+    app.get('/api/orders', (req, res) => {
+        const auth = req.headers['authorization'] || '';
+        if (auth !== 'Bearer ' + DASHBOARD_TOKEN) {
+            return res.status(401).json({ error: 'Non autorisé' });
+        }
+        res.json({ orders: Array.from(orders.values()), total: orders.size });
+    });
+}
+
+/* ── Route racine ── */
+const ROOT_FILE = IS_DASHBOARD ? 'dashboard.html' : 'index.html';
 
 app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, ROOT_FILE));
 });
 
-app.listen(PORT, () => {
-    console.log(`OLDA Studio démarré sur le port ${PORT}`);
+server.listen(PORT, () => {
+    const mode = IS_DASHBOARD ? 'Dashboard (temps réel activé)' : 'Site client';
+    console.log(`OLDA Studio — ${mode} — port ${PORT}`);
 });


### PR DESCRIPTION
- server.js : ajout Socket.io + endpoint POST /api/orders (reçoit les commandes du site client avec token Bearer) + GET /api/stats + CORS cross-origin
- dashboard.html : remplacement du polling 30s par Socket.io (stats-update, new-order) avec notification visuelle instantanée + fallback HTTP
- index.html : DASHBOARD_URL fixé sur dashboardolda-production.up.railway.app
- package.json : ajout dépendance socket.io ^4.7.5

Flux : oldastudio.up.railway.app → HTTP POST → dashboard → Socket.io → UI

https://claude.ai/code/session_014HwXfWYNBxcnqbUnNo5pvu