### PR TITLE
feat: créer ficheatelier-index.html (fiche atelier)

### DIFF
--- a/ficheatelier-index.html
+++ b/ficheatelier-index.html
@@ -1,0 +1,447 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Fiche Atelier — Studio Olda</title>
+    <link rel="apple-touch-icon" href="apple-touch-icon.png">
+    <link rel="icon" type="image/svg+xml" href="olda-icon.svg">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <style>
+        :root {
+            --accent: #007AFF;
+            --green: #34C759;
+            --red: #FF3B30;
+            --orange: #FF9500;
+            --bg: #F2F2F7;
+            --card: #FFFFFF;
+            --border: rgba(0,0,0,0.07);
+            --text-1: #1C1C1E;
+            --text-2: #6C6C70;
+            --text-3: #AEAEB2;
+            --radius: 14px;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; -webkit-font-smoothing: antialiased; }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Helvetica Neue', Arial, sans-serif;
+            background: var(--bg);
+            color: var(--text-1);
+            min-height: 100vh;
+            letter-spacing: -0.02em;
+        }
+
+        /* ── Wrapper ── */
+        .page {
+            max-width: 640px;
+            margin: 0 auto;
+            padding: 24px 16px 80px;
+        }
+
+        /* ── Header ── */
+        .header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 24px;
+        }
+        .header-brand {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .brand-dot {
+            width: 32px; height: 32px; border-radius: 8px;
+            background: var(--text-1);
+            display: flex; align-items: center; justify-content: center;
+        }
+        .brand-dot span {
+            color: white; font-size: 13px; font-weight: 800; letter-spacing: -0.5px;
+        }
+        .brand-name {
+            font-size: 17px; font-weight: 700; color: var(--text-1);
+        }
+        .btn-print {
+            display: flex; align-items: center; gap: 6px;
+            background: var(--text-1); color: white;
+            border: none; border-radius: 10px;
+            padding: 10px 16px; font-size: 14px; font-weight: 600;
+            cursor: pointer; font-family: inherit; letter-spacing: -0.02em;
+            transition: opacity 0.15s;
+        }
+        .btn-print:active { opacity: 0.75; }
+
+        /* ── Titre section ── */
+        .section-title {
+            font-size: 11px; font-weight: 700;
+            text-transform: uppercase; letter-spacing: 0.12em;
+            color: var(--text-3); margin-bottom: 8px; padding-left: 4px;
+        }
+
+        /* ── Card ── */
+        .card {
+            background: var(--card);
+            border-radius: var(--radius);
+            box-shadow: 0 1px 3px rgba(0,0,0,0.04), 0 0 0 0.5px rgba(0,0,0,0.03);
+            margin-bottom: 16px;
+            overflow: hidden;
+        }
+
+        /* ── Row ── */
+        .row {
+            display: flex;
+            align-items: center;
+            padding: 14px 16px;
+            border-bottom: 0.5px solid var(--border);
+            gap: 12px;
+        }
+        .row:last-child { border-bottom: none; }
+
+        .row-label {
+            font-size: 12px; font-weight: 600;
+            text-transform: uppercase; letter-spacing: 0.1em;
+            color: var(--text-3);
+            width: 88px; flex-shrink: 0;
+        }
+        .row-value {
+            font-size: 15px; font-weight: 500;
+            color: var(--text-1); flex: 1;
+            word-break: break-word;
+        }
+        .row-value.mono {
+            font-variant-numeric: tabular-nums;
+            letter-spacing: 0.02em;
+            font-size: 14px;
+        }
+        .row-value.large {
+            font-size: 17px; font-weight: 700;
+        }
+        .row-value.muted { color: var(--text-2); }
+        .row-value.dim { color: var(--text-3); font-style: italic; }
+
+        /* ── Couleur swatch inline ── */
+        .color-chip {
+            display: inline-flex; align-items: center; gap: 8px;
+        }
+        .color-swatch {
+            width: 22px; height: 22px; border-radius: 50%;
+            border: 1.5px solid rgba(0,0,0,0.1);
+            flex-shrink: 0;
+        }
+
+        /* ── Badge statut paiement ── */
+        .badge {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 20px;
+            font-size: 13px; font-weight: 600;
+        }
+        .badge-paye { background: rgba(52,199,89,0.12); color: var(--green); }
+        .badge-attente { background: rgba(255,59,48,0.10); color: var(--red); }
+        .badge-bio { background: rgba(52,199,89,0.1); color: #248A3D; font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; padding: 3px 8px; }
+
+        /* ── Prix ── */
+        .prix-row {
+            display: flex; justify-content: space-between; align-items: center;
+            padding: 12px 16px;
+            border-bottom: 0.5px solid var(--border);
+        }
+        .prix-row:last-child { border-bottom: none; }
+        .prix-label { font-size: 15px; color: var(--text-2); }
+        .prix-val { font-size: 15px; font-weight: 500; color: var(--text-1); }
+        .prix-total-row {
+            display: flex; justify-content: space-between; align-items: center;
+            padding: 14px 16px;
+        }
+        .prix-total-label { font-size: 16px; font-weight: 700; }
+        .prix-total-val { font-size: 20px; font-weight: 800; color: var(--text-1); }
+
+        /* ── Mockups ── */
+        .mockup-grid {
+            display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+            margin-bottom: 16px;
+        }
+        .mockup-block {
+            background: var(--card);
+            border-radius: var(--radius);
+            box-shadow: 0 1px 3px rgba(0,0,0,0.04), 0 0 0 0.5px rgba(0,0,0,0.03);
+            padding: 14px 14px 10px;
+            display: flex; flex-direction: column; align-items: center; gap: 8px;
+        }
+        .mockup-block img {
+            width: 100%; max-width: 180px; height: auto;
+            border-radius: 8px;
+        }
+        .mockup-label {
+            font-size: 11px; font-weight: 600; text-transform: uppercase;
+            letter-spacing: 0.12em; color: var(--text-3);
+        }
+        .mockup-empty {
+            width: 100%; aspect-ratio: 4/5;
+            display: flex; align-items: center; justify-content: center;
+            background: var(--bg); border-radius: 8px;
+        }
+        .mockup-empty span { font-size: 12px; color: var(--text-3); }
+
+        /* ── Note ── */
+        .note-block {
+            padding: 14px 16px;
+            font-size: 15px; color: var(--text-1); line-height: 1.5;
+            background: rgba(255,149,0,0.06);
+            border-left: 3px solid var(--orange);
+        }
+
+        /* ── Empty state ── */
+        .empty-state {
+            text-align: center; padding: 80px 32px;
+        }
+        .empty-state h2 { font-size: 22px; font-weight: 700; margin-bottom: 10px; }
+        .empty-state p { font-size: 15px; color: var(--text-2); line-height: 1.5; }
+        .empty-btn {
+            display: inline-block; margin-top: 24px;
+            background: var(--accent); color: white;
+            padding: 14px 28px; border-radius: 12px;
+            text-decoration: none; font-size: 15px; font-weight: 600;
+        }
+
+        /* ── Deadline badge ── */
+        .deadline-chip {
+            display: inline-flex; align-items: center; gap: 6px;
+            font-size: 14px; font-weight: 500; color: var(--text-1);
+        }
+
+        /* ── Séparateur total ── */
+        .separator { height: 0.5px; background: var(--border); margin: 0; }
+
+        /* ════════════ PRINT ════════════ */
+        @media print {
+            body { background: white; }
+            .page { padding: 12px; max-width: 100%; }
+            .btn-print { display: none; }
+            .card { box-shadow: 0 0 0 1px #ddd; page-break-inside: avoid; margin-bottom: 12px; }
+            .mockup-grid { page-break-inside: avoid; }
+        }
+
+        /* ── Desktop ── */
+        @media (min-width: 600px) {
+            .page { padding: 40px 24px 80px; }
+            body { background: #E8E8ED; }
+        }
+    </style>
+</head>
+<body>
+
+<div class="page" id="pageContent">
+
+    <div class="header">
+        <div class="header-brand">
+            <div class="brand-dot"><span>OA</span></div>
+            <span class="brand-name">Fiche Atelier</span>
+        </div>
+        <button class="btn-print" onclick="window.print()">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="6 9 6 2 18 2 18 9"/>
+                <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/>
+                <rect x="6" y="14" width="12" height="8"/>
+            </svg>
+            Imprimer
+        </button>
+    </div>
+
+    <div id="ficheContent"></div>
+
+</div>
+
+<script>
+(function () {
+    'use strict';
+
+    /* ── 1. Charger les données ── */
+    function loadFiche() {
+        /* Priorité 1 : hash URL (lien depuis Google Sheets) */
+        const hash = window.location.hash.slice(1);
+        if (hash && hash.length > 10) {
+            try {
+                return JSON.parse(decodeURIComponent(escape(atob(hash))));
+            } catch (e) { /* ignore, essaie le localStorage */ }
+        }
+        /* Priorité 2 : localStorage (dernière commande enregistrée) */
+        try {
+            const all = JSON.parse(localStorage.getItem('olda_fiches') || '{}');
+            const keys = Object.keys(all);
+            if (keys.length === 0) return null;
+            /* Retourne la plus récente (dernier ajouté) */
+            return all[keys[keys.length - 1]];
+        } catch (e) { return null; }
+    }
+
+    /* ── 2. Helpers ── */
+    function esc(s) {
+        return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+
+    function fmtDate(str) {
+        if (!str) return '—';
+        /* Format ISO (2026-02-20) → jj/mm/aaaa */
+        if (/^\d{4}-\d{2}-\d{2}$/.test(str)) {
+            const [y, m, d] = str.split('-');
+            return `${d}/${m}/${y}`;
+        }
+        return esc(str);
+    }
+
+    function fmtPrice(v) {
+        if (v === undefined || v === null || v === '') return '—';
+        return Number(v).toLocaleString('fr-FR', { style: 'currency', currency: 'EUR' });
+    }
+
+    function logoLabel(id) {
+        if (!id) return '<span class="muted">Aucun</span>';
+        if (id === 'Custom') return 'Logo personnalisé';
+        return esc(id);
+    }
+
+    /* ── 3. Rendu ── */
+    function render(f) {
+        const paye = f.paiement && (f.paiement.statut === 'oui' || f.paiement.statut === 'payé');
+        const couleurHex = (f.couleur && f.couleur.hex) ? f.couleur.hex : '#CCCCCC';
+        const couleurNom = (f.couleur && f.couleur.nom) ? f.couleur.nom : '—';
+        const hasMockupF = !!f.mockupFront;
+        const hasMockupB = !!f.mockupBack;
+
+        let html = '';
+
+        /* ── Commande header ── */
+        html += `
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;flex-wrap:wrap;gap:10px;">
+            <div>
+                <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.14em;color:var(--text-3);margin-bottom:4px;">Commande</div>
+                <div style="font-size:22px;font-weight:800;letter-spacing:-0.03em;color:var(--text-1);">${esc(f.commande || '—')}</div>
+            </div>
+            <span class="badge ${paye ? 'badge-paye' : 'badge-attente'}">${paye ? '✓ Payé' : 'À régler'}</span>
+        </div>`;
+
+        /* ── Mockups ── */
+        if (hasMockupF || hasMockupB) {
+            html += `<div class="mockup-grid">`;
+            html += `<div class="mockup-block">`;
+            if (hasMockupF) {
+                html += `<img src="${f.mockupFront}" alt="Avant">`;
+            } else {
+                html += `<div class="mockup-empty"><span>Pas de visuel</span></div>`;
+            }
+            html += `<span class="mockup-label">Avant</span></div>`;
+
+            html += `<div class="mockup-block">`;
+            if (hasMockupB) {
+                html += `<img src="${f.mockupBack}" alt="Arrière">`;
+            } else {
+                html += `<div class="mockup-empty"><span>Pas de visuel</span></div>`;
+            }
+            html += `<span class="mockup-label">Arrière</span></div>`;
+            html += `</div>`;
+        }
+
+        /* ── Client ── */
+        html += `<div class="section-title">Client</div>`;
+        html += `<div class="card">`;
+        html += row('Nom', esc(f.nom || '—'), 'large');
+        html += row('Téléphone', esc(f.telephone || '—'), 'mono');
+        html += row('Date', fmtDate(f.date));
+        if (f.deadline) {
+            html += row('Deadline', `<span class="deadline-chip"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>${fmtDate(f.deadline)}</span>`);
+        }
+        html += `</div>`;
+
+        /* ── Produit ── */
+        html += `<div class="section-title">Produit</div>`;
+        html += `<div class="card">`;
+        html += row('Collection', esc(f.collection || '—'));
+        html += row('Référence', `${esc(f.reference || '—')}${f.bio ? ' <span class="badge badge-bio">Bio</span>' : ''}`);
+        if (f.refDesc) {
+            html += row('Description', `<span style="font-size:13px;color:var(--text-2);">${esc(f.refDesc)}</span>`);
+        }
+        html += row('Taille', `<strong>${esc(f.taille || '—')}</strong>`);
+        html += row('Couleur', `<span class="color-chip"><span class="color-swatch" style="background:${esc(couleurHex)};"></span>${esc(couleurNom)}</span>`);
+        html += `</div>`;
+
+        /* ── Personnalisation ── */
+        html += `<div class="section-title">Personnalisation</div>`;
+        html += `<div class="card">`;
+        html += row('Logo Avant',
+            (f.logoAvant ? `${logoLabel(f.logoAvant)}${f.couleurLogoAvant ? `<span style="color:var(--text-2);font-size:13px;"> — ${esc(f.couleurLogoAvant)}</span>` : ''}` : '<span class="dim">Aucun logo</span>')
+        );
+        html += row('Logo Arrière',
+            (f.logoArriere ? `${logoLabel(f.logoArriere)}${f.couleurLogoArriere ? `<span style="color:var(--text-2);font-size:13px;"> — ${esc(f.couleurLogoArriere)}</span>` : ''}` : '<span class="dim">Aucun logo</span>')
+        );
+        if (f.coteLogoAr && f.coteLogoAr !== 'centre') {
+            html += row('Position Ar.', esc(f.coteLogoAr));
+        }
+        html += `</div>`;
+
+        /* ── Note ── */
+        if (f.note && f.note.trim()) {
+            html += `<div class="section-title">Note</div>`;
+            html += `<div class="card"><div class="note-block">${esc(f.note)}</div></div>`;
+        }
+
+        /* ── Paiement ── */
+        html += `<div class="section-title">Paiement</div>`;
+        html += `<div class="card">`;
+        if (f.prix) {
+            if (f.prix.tshirt !== undefined && f.prix.tshirt !== '') {
+                html += `<div class="prix-row"><span class="prix-label">T-shirt</span><span class="prix-val">${fmtPrice(f.prix.tshirt)}</span></div>`;
+            }
+            if (f.prix.personnalisation !== undefined && f.prix.personnalisation !== '') {
+                html += `<div class="prix-row"><span class="prix-label">Personnalisation</span><span class="prix-val">${fmtPrice(f.prix.personnalisation)}</span></div>`;
+            }
+            if (f.prix.total !== undefined && f.prix.total !== '') {
+                html += `<div class="separator"></div>`;
+                html += `<div class="prix-total-row"><span class="prix-total-label">Total</span><span class="prix-total-val">${fmtPrice(f.prix.total)}</span></div>`;
+            }
+        }
+        html += `</div>`;
+
+        /* ── Statut paiement ── */
+        html += `<div class="card">`;
+        html += row('Statut', `<span class="badge ${paye ? 'badge-paye' : 'badge-attente'}">${paye ? '✓ Payé' : 'À régler'}</span>`);
+        html += `</div>`;
+
+        document.getElementById('ficheContent').innerHTML = html;
+    }
+
+    function row(label, valueHtml, cls) {
+        return `<div class="row"><span class="row-label">${label}</span><span class="row-value ${cls || ''}">${valueHtml}</span></div>`;
+    }
+
+    /* ── 4. Empty state ── */
+    function renderEmpty() {
+        document.getElementById('ficheContent').innerHTML = `
+        <div class="empty-state">
+            <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="#AEAEB2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="margin:0 auto 16px;display:block;">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                <polyline points="14 2 14 8 20 8"/>
+                <line x1="16" y1="13" x2="8" y2="13"/>
+                <line x1="16" y1="17" x2="8" y2="17"/>
+                <polyline points="10 9 9 9 8 9"/>
+            </svg>
+            <h2>Aucune fiche trouvée</h2>
+            <p>Validez une commande depuis le Studio pour<br>générer automatiquement la fiche atelier.</p>
+            <a href="index.html" class="empty-btn">Retour au Studio →</a>
+        </div>`;
+    }
+
+    /* ── 5. Init ── */
+    const fiche = loadFiche();
+    if (fiche) {
+        render(fiche);
+    } else {
+        renderEmpty();
+    }
+
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Page standalone qui affiche la fiche récapitulative d'une commande. Lecture des données depuis :
  1. URL hash (base64 JSON) → lien envoyé dans Google Sheets
  2. localStorage (olda_fiches) → dernière commande enregistrée

Contenu de la fiche :
- En-tête commande + badge paiement
- Mockups avant/arrière (si disponibles)
- Bloc client (nom, téléphone, date, deadline)
- Bloc produit (collection, référence, taille, couleur swatch)
- Bloc personnalisation (logos avant/arrière + couleurs)
- Note atelier (si renseignée)
- Récapitulatif prix + statut paiement
- Bouton impression

https://claude.ai/code/session_014HwXfWYNBxcnqbUnNo5pvu