### PR TITLE
feat: envoi dashboard avec famille + token mis à jour

### DIFF
--- a/index.html
+++ b/index.html
@@ -1363,7 +1363,7 @@ const API = "https://script.google.com/macros/s/AKfycbyzeU0tD22L8wZ94PW0f4s1a2LH
 
 /* ── Dashboard OLDA — même domaine que le formulaire ── */
 const DASHBOARD_URL   = 'https://dashboardolda-production.up.railway.app';
-const DASHBOARD_TOKEN = "d1e9c4cd170eb57f8ce6254b5aa70b7f708e465d48daefc7f3b0b7e16bd9f4dc";
+const DASHBOARD_TOKEN = "a3f8d2c1e4b5a9f0d7e6c3b2a1f8e5d4c7b6a3f2e1d0c9b8a7f6e5d4c3b2a1f0";
 
 const COLORS = [
     /* ── Basiques (les + commandés) ── */
@@ -1739,7 +1739,11 @@ document.addEventListener('DOMContentLoaded', async () => {
    ══════════════════════════════════════ */
 const TITLES = ['Client','Studio','Paiement'];
 
+/* Famille sélectionnée au Step 0 (textile par défaut) */
+let selectedFamily = 'textile';
+
 window.selectFamily = function(family) {
+    selectedFamily = family;   /* stocker pour l'inclure dans le payload */
     go(1);
 };
 
@@ -2391,13 +2395,14 @@ async function sendOrderToDashboard(orderPayload, ficheData) {
         couleurLogoAvant  : orderPayload.couleurLogoAvant,
         couleurLogoArriere: orderPayload.couleurLogoArriere,
         note              : orderPayload.note,
+        famille           : orderPayload.famille || 'textile',
         prix              : {
             tshirt          : orderPayload.prixTshirt,
             personnalisation: orderPayload.personnalisation,
             total           : orderPayload.total
         },
         paiement          : { statut: orderPayload.paye },
-        source            : 'site-client',
+        source            : 'oldastudio',
         timestamp         : new Date().toISOString()
     };
 
@@ -2482,7 +2487,8 @@ window.submit = async function() {
         prixTshirt        : (selects['selPrice']  && selects['selPrice'].value)  || '0',
         personnalisation  : (selects['selPerso']  && selects['selPerso'].value)  || '0',
         total             : String((parseFloat(selects['selPrice']?.value)||0)+(parseFloat(selects['selPerso']?.value)||0)),
-        paye              : payStatus === 'oui' ? 'OUI' : 'NON'
+        paye              : payStatus === 'oui' ? 'OUI' : 'NON',
+        famille           : selectedFamily
     };
 
     /* ── Build fiche data (synchrone) ── */
@@ -2529,6 +2535,9 @@ window.submit = async function() {
 
     /* ── Envoi Google Sheets (best-effort, non-bloquant) ── */
     fetch(API, { method: 'POST', mode: 'no-cors', body: JSON.stringify(payload) }).catch(() => {});
+
+    /* ── Envoi Dashboard OLDA (avec famille + mockups) ── */
+    sendOrderToDashboard(payload, ficheComplete);
 
     /* ── Sauvegarde fiche dans localStorage (même domaine = même dashboard) ── */
     try {


### PR DESCRIPTION
- Mise à jour DASHBOARD_TOKEN avec le nouveau token API
- Ajout du champ `famille` (textile/mug/accessoire) stocké depuis le Step 0 et inclus dans le payload envoyé au dashboard
- Correction `source` → "oldastudio" (était "site-client")
- Appel manquant de sendOrderToDashboard() ajouté dans submit() (la fonction était définie mais jamais appelée)

https://claude.ai/code/session_014HwXfWYNBxcnqbUnNo5pvu