### PR TITLE
Remplace champs logo texte par Taille DTF arrière (dropdown)

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,27 +125,6 @@
             letter-spacing: -0.022em;
         }
         .aselect-trigger.placeholder { color: var(--text-3); }
-
-        /* ── Logo inputs (modifiables manuellement) ── */
-        .logo-input {
-            background: var(--bg);
-            border: 1.5px solid transparent;
-            border-radius: var(--radius);
-            padding: 14px 16px;
-            font-size: 16px;
-            color: var(--text-1);
-            font-family: inherit;
-            letter-spacing: -0.022em;
-            width: 100%;
-            display: block;
-            outline: none;
-            transition: border-color 0.2s, box-shadow 0.2s;
-        }
-        .logo-input:focus {
-            border-color: var(--accent);
-            box-shadow: 0 0 0 3.5px rgba(0,122,255,0.12);
-        }
-        .logo-input::placeholder { color: var(--text-3); }
         .aselect.open .aselect-trigger { border-color: var(--accent); box-shadow: 0 0 0 3.5px rgba(0,122,255,0.12); }
 
         .aselect-chevron {
@@ -1226,18 +1205,6 @@
             <div class="aselect" id="selRef"></div>
         </div>
 
-        <!-- Logo Avant -->
-        <div class="card p-5">
-            <label class="label ml-1 mb-2 block">Logo Avant</label>
-            <input type="text" id="logoAvantInput" class="logo-input" placeholder="Aucun">
-        </div>
-
-        <!-- Logo Arrière -->
-        <div class="card p-5">
-            <label class="label ml-1 mb-2 block">Logo Arrière</label>
-            <input type="text" id="logoArriereInput" class="logo-input" placeholder="Aucun">
-        </div>
-
         <!-- Couleur T-shirt — menu déroulant -->
         <div class="card p-5">
             <label class="label ml-1 mb-2 block">Couleur T-shirt</label>
@@ -1248,6 +1215,12 @@
         <div class="card p-5">
             <label class="label ml-1 mb-2 block">Taille</label>
             <div class="aselect" id="selSize"></div>
+        </div>
+
+        <!-- Taille DTF arrière -->
+        <div class="card p-5">
+            <label class="label ml-1 mb-2 block">Taille DTF arrière</label>
+            <div class="aselect" id="selTailleDtf"></div>
         </div>
 
 
@@ -1733,6 +1706,19 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.querySelector('#selSize .aselect-trigger').textContent = 'S';
     document.querySelector('#selSize .aselect-trigger').classList.remove('placeholder');
 
+    // Taille DTF arrière
+    createSelect('selTailleDtf',
+        [
+            {v:'',     l:'Aucun'},
+            {v:'A5',   l:'A5 — 15×21 cm'},
+            {v:'A4',   l:'A4 — 21×30 cm'},
+            {v:'A3',   l:'A3 — 30×42 cm'},
+            {v:'A2',   l:'A2 — 42×59 cm'}
+        ],
+        'Taille DTF arrière',
+        () => {}
+    );
+
     // Couleur T-shirt — menu déroulant
     initColorSelect();
 
@@ -1917,26 +1903,12 @@ function renderLogoForSide(s) {
 }
 
 /* renderLogo — appelé pour rafraîchir les deux côtés */
-function updateLogoInputs() {
-    const av = document.getElementById('logoAvantInput');
-    const ar = document.getElementById('logoArriereInput');
-    if (av) {
-        const fd = logos.front.data;
-        av.value = fd ? (fd.n || fd.name || fd.id || '') : '';
-    }
-    if (ar) {
-        const bd = logos.back.data;
-        ar.value = bd ? (bd.n || bd.name || bd.id || '') : '';
-    }
-}
-
 function renderLogo() {
     renderLogoForSide('front');
     renderLogoForSide('back');
     updateFloatBar();
     updateTapOverlays();
     updateLogoMmDisplay();
-    updateLogoInputs();
 }
 
 function updateLogoPositionForSide(s) {
@@ -2522,16 +2494,15 @@ window.submit = async function() {
         collection        : collVal || '',
         reference         : refVal  || '',
         taille            : sizeVal || '',
+        tailleDtf         : (selects['selTailleDtf'] && selects['selTailleDtf'].value) || '',
         couleurTshirt     : color.n,
         couleurTshirtHex  : color.h,
         couleurLogoAvant  : logos.front.data && logos.front.data.type === 'atelier'
                             ? logoColorName(logos.front.logoColor, LOGO_COLORS) : '',
         couleurLogoArriere: logos.back.data  && logos.back.data.type  === 'atelier'
                             ? logoColorName(logos.back.logoColor,  LOGO_COLORS) : '',
-        logoAvant         : (document.getElementById('logoAvantInput')?.value.trim()) ||
-                            (logos.front.data ? (logos.front.data.type === 'atelier' ? logos.front.data.id : 'Custom') : ''),
-        logoArriere       : (document.getElementById('logoArriereInput')?.value.trim()) ||
-                            (logos.back.data  ? (logos.back.data.type  === 'atelier' ? logos.back.data.id  : 'Custom') : ''),
+        logoAvant         : logos.front.data ? (logos.front.data.type === 'atelier' ? logos.front.data.id : 'Custom') : '',
+        logoArriere       : logos.back.data  ? (logos.back.data.type  === 'atelier' ? logos.back.data.id  : 'Custom') : '',
         note              : (document.getElementById('note').value || '').trim(),
         prixTshirt        : (selects['selPrice']  && selects['selPrice'].value)  || '0',
         personnalisation  : (selects['selPerso']  && selects['selPerso'].value)  || '0',


### PR DESCRIPTION
- Supprime les inputs Logo Avant/Arrière ajoutés précédemment
- La sélection des logos reste via l'interface visuelle T-shirt (inchangée)
- Ajoute champ "Taille DTF arrière" (aselect) après Taille : Aucun / A5 / A4 / A3 / A2
- Ajoute tailleDtf dans le payload submit