### PR TITLE
feat: redirect orders to dasholda.up.railway.app, remove fiche from p…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1357,8 +1357,8 @@
    ══════════════════════════════════════ */
 const API = "https://script.google.com/macros/s/AKfycbyzeU0tD22L8wZ94PW0f4s1a2LH7fNPhK74RtjcIXs0pWAP59anDV8EYtYlP8WX5iCk/exec";
 
-/* ── Dashboard OLDA — même domaine que le formulaire ── */
-const DASHBOARD_URL   = 'https://dashboardolda-production.up.railway.app';
+/* ── Dashboard OLDA ── */
+const DASHBOARD_URL   = 'https://dasholda.up.railway.app';
 const DASHBOARD_TOKEN = "a3f8d2c1e4b5a9f0d7e6c3b2a1f8e5d4c7b6a3f2e1d0c9b8a7f6e5d4c3b2a1f0";
 
 const COLORS = [
@@ -2394,19 +2394,6 @@ async function sendOrderToDashboard(orderPayload, ficheData) {
         timestamp         : new Date().toISOString()
     };
 
-    /* ── Ajouter les données de fiche complètes ── */
-    if (ficheData) {
-        orderData.fiche = {
-            deadline          : ficheData.deadline || '',
-            refDesc           : ficheData.refDesc || '',
-            bio               : ficheData.bio || false,
-            couleur           : ficheData.couleur || {},
-            coteLogoAr        : ficheData.coteLogoAr || '',
-            mockupFront       : ficheData.mockupFront || null,
-            mockupBack        : ficheData.mockupBack || null
-        };
-    }
-
     try {
         var response = await fetch(DASHBOARD_URL + '/api/orders', {
             method : 'POST',
@@ -2597,11 +2584,8 @@ window.submit = async function() {
     /* ── Envoi Google Sheets (best-effort, non-bloquant) ── */
     fetch(API, { method: 'POST', mode: 'no-cors', body: JSON.stringify(payload) }).catch(() => {});
 
-    /* ── Envoi Dashboard OLDA (avec famille + mockups) ── */
+    /* ── Envoi Dashboard OLDA (dasholda.up.railway.app) ── */
     sendOrderToDashboard(payload, ficheComplete);
-
-    /* ── Transfert automatique vers DASHOLDA (relay serveur, best-effort) ── */
-    sendOrderToDasholda(payload, ficheComplete);
 
     /* ── Sauvegarde fiche dans localStorage (même domaine = même dashboard) ── */
     try {

--- a/server.js
+++ b/server.js
@@ -288,7 +288,11 @@ app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, ROOT_FILE));
 });
 
-/* ── Route analytics ── */
+/* ── Routes dashboard ── */
+app.get('/dashboard', (req, res) => {
+    res.sendFile(path.join(__dirname, 'dashboard.html'));
+});
+
 app.get('/dashboard/analytics', (req, res) => {
     res.sendFile(path.join(__dirname, 'analytics.html'));
 });


### PR DESCRIPTION
…ayload

- index.html: change DASHBOARD_URL to https://dasholda.up.railway.app so all new orders are sent directly to the DASHOLDA dashboard
- index.html: remove fiche data (mockupFront/Back, deadline, refDesc, etc.) from the dashboard order payload — orders are now lighter and faster
- index.html: remove duplicate sendOrderToDasholda relay call; a single sendOrderToDashboard call now handles the transmission
- server.js: add GET /dashboard route serving dashboard.html so the dashboard is accessible at /dashboard in addition to /

https://claude.ai/code/session_01Kjhoy5CaidqqA9FAV2wwyt