### PR TITLE
fix: align DASHBOARD_TOKEN with server default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1359,7 +1359,7 @@ const API = "https://script.google.com/macros/s/AKfycbyzeU0tD22L8wZ94PW0f4s1a2LH
 
 /* ── Dashboard OLDA ── */
 const DASHBOARD_URL   = 'https://dasholda.up.railway.app';
-const DASHBOARD_TOKEN = "a3f8d2c1e4b5a9f0d7e6c3b2a1f8e5d4c7b6a3f2e1d0c9b8a7f6e5d4c3b2a1f0";
+const DASHBOARD_TOKEN = "d1e9c4cd170eb57f8ce6254b5aa70b7f708e465d48daefc7f3b0b7e16bd9f4dc";
 
 const COLORS = [
     /* ── Basiques (les + commandés) ── */


### PR DESCRIPTION
index.html was using a different token than the server's default value, causing all POST /api/orders requests to return 401 Unauthorized. Token now matches server.js default so no env var config is needed.

https://claude.ai/code/session_01Kjhoy5CaidqqA9FAV2wwyt