### PR TITLE
fix: default to dashboard mode, require SITE_MODE=form for form site

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,8 @@ const app    = express();
 const server = http.createServer(app);
 const PORT   = process.env.PORT || 3000;
 
-const IS_DASHBOARD    = process.env.SITE_MODE === 'dashboard';
+/* Dashboard actif par défaut — mettre SITE_MODE=form pour le site formulaire */
+const IS_DASHBOARD    = process.env.SITE_MODE !== 'form';
 const DASHBOARD_TOKEN = process.env.DASHBOARD_TOKEN || 'd1e9c4cd170eb57f8ce6254b5aa70b7f708e465d48daefc7f3b0b7e16bd9f4dc';
 const CLIENT_ORIGIN   = process.env.CLIENT_ORIGIN  || 'https://oldastudio.up.railway.app';
 


### PR DESCRIPTION
Previously IS_DASHBOARD required SITE_MODE=dashboard to be set, so dasholda.up.railway.app with no env vars had all dashboard routes disabled (no /api/stats, no /api/orders GET, no Socket.io).

Now IS_DASHBOARD defaults to true — the dashboard is always active unless SITE_MODE=form is explicitly set (for oldastudio.up.railway.app). No env var needed on the dashboard deployment.

https://claude.ai/code/session_01Kjhoy5CaidqqA9FAV2wwyt