### PR TITLE
fix: prevent white page crash when adding 3+ items to cart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, Component, type ReactNode } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { CartProvider } from './context/CartContext';
 import Studio from './components/Studio';
@@ -7,6 +7,31 @@ import Payment from './components/Payment';
 import CartBadge from './components/CartBadge';
 import CartDrawer from './components/CartDrawer';
 import type { Step, ClientInfo, CartItem } from './types';
+
+class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  state = { error: null };
+  static getDerivedStateFromError(error: Error) { return { error }; }
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '100vh', padding: 24, gap: 16, textAlign: 'center' }}>
+          <div style={{ fontSize: 40 }}>⚠️</div>
+          <div style={{ fontSize: 18, fontWeight: 700 }}>Une erreur est survenue</div>
+          <div style={{ fontSize: 13, color: '#666', maxWidth: 320 }}>
+            {(this.state.error as Error).message || 'Erreur inattendue'}
+          </div>
+          <button
+            style={{ marginTop: 8, padding: '10px 24px', borderRadius: 10, background: '#007AFF', color: '#fff', border: 'none', fontWeight: 600, cursor: 'pointer' }}
+            onClick={() => { localStorage.removeItem('olda_cart_v1'); window.location.reload(); }}
+          >
+            Réinitialiser et recharger
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 const STEP_LABELS: Record<Step, string> = {
   studio:  'Studio',
@@ -145,8 +170,10 @@ function AppInner() {
 
 export default function App() {
   return (
-    <CartProvider>
-      <AppInner />
-    </CartProvider>
+    <ErrorBoundary>
+      <CartProvider>
+        <AppInner />
+      </CartProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -27,7 +27,22 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<CartItem[]>(loadCart);
 
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    } catch {
+      // QuotaExceededError : on re-tente sans les données base64 (images uploadées)
+      try {
+        const stripped = items.map(item => ({
+          ...item,
+          logoAvant:   { ...item.logoAvant,   url: null },
+          logoArriere: { ...item.logoArriere, url: null },
+        }));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(stripped));
+      } catch {
+        // Si toujours impossible, on ne plante pas — le panier reste en mémoire
+        console.warn('[Cart] localStorage plein — sauvegarde du panier impossible.');
+      }
+    }
   }, [items]);
 
   const addItem = (item: CartItem) => setItems(prev => [...prev, item]);


### PR DESCRIPTION
- CartContext: wrap localStorage.setItem in try/catch to handle QuotaExceededError gracefully (strips base64 image URLs and retries, avoids crashing on storage full)
- App: add ErrorBoundary component so any unhandled render error shows a user-friendly message with a reset button instead of a blank white page
- Studio: add 2MB upload size limit to prevent oversized base64 data from filling localStorage; cancel previous flash timer before starting a new one to avoid multiple overlapping timeouts when items are added in quick succession

https://claude.ai/code/session_01QKYn9GiSZirjQ12GhWJAwF

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
